### PR TITLE
[Feature/#4 CustomBottomSheet 컴포넌트 구현

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,5 +1,7 @@
+﻿import { BottomSheetModalProvider } from "@gorhom/bottom-sheet";
 import { Stack } from "expo-router";
 import * as SplashScreen from "expo-splash-screen";
+import { GestureHandlerRootView } from "react-native-gesture-handler";
 import {
   SafeAreaView,
   useSafeAreaInsets,
@@ -19,24 +21,38 @@ export default function RootLayout() {
   const insets = useSafeAreaInsets();
 
   return (
-    <SafeAreaView style={{ flex: 1, backgroundColor: colors.black.main }}>
-      <Stack>
-        <Stack.Screen
-          name="(tabs)"
-          options={{ headerShown: false, gestureEnabled: false }}
-        />
-        <Stack.Screen
-          name="login"
-          options={{ headerShown: false, gestureEnabled: false }}
-        />
-        <Stack.Screen name="sign-up" options={{ headerShown: false }} />
-        <Stack.Screen name="alarm" options={{ headerShown: false }} />
-        <Stack.Screen name="book-request" options={{ headerShown: false }} />
-        <Stack.Screen name="my-thip-list" options={{ headerShown: false }} />
-        <Stack.Screen name="(user)" options={{ headerShown: false }} />
-      </Stack>
-      <Toast config={toastConfig} position="top" topOffset={insets.top + 16} />
-      {/* <Toast position="top" topOffset={60} /> */}
-    </SafeAreaView>
+    <GestureHandlerRootView style={{ flex: 1 }}>
+      <BottomSheetModalProvider>
+        <SafeAreaView style={{ flex: 1, backgroundColor: colors.black.main }}>
+          <Stack>
+            <Stack.Screen
+              name="(tabs)"
+              options={{ headerShown: false, gestureEnabled: false }}
+            />
+            <Stack.Screen
+              name="login"
+              options={{ headerShown: false, gestureEnabled: false }}
+            />
+            <Stack.Screen name="sign-up" options={{ headerShown: false }} />
+            <Stack.Screen name="alarm" options={{ headerShown: false }} />
+            <Stack.Screen
+              name="book-request"
+              options={{ headerShown: false }}
+            />
+            <Stack.Screen
+              name="my-thip-list"
+              options={{ headerShown: false }}
+            />
+            <Stack.Screen name="(user)" options={{ headerShown: false }} />
+          </Stack>
+          <Toast
+            config={toastConfig}
+            position="top"
+            topOffset={insets.top + 16}
+          />
+          {/* <Toast position="top" topOffset={60} /> */}
+        </SafeAreaView>
+      </BottomSheetModalProvider>
+    </GestureHandlerRootView>
   );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@expo/vector-icons": "^15.0.3",
+        "@gorhom/bottom-sheet": "^5.2.8",
         "@react-navigation/bottom-tabs": "^7.4.0",
         "@react-navigation/elements": "^2.6.3",
         "@react-navigation/native": "^7.1.8",
@@ -2219,6 +2220,45 @@
       "license": "MIT",
       "dependencies": {
         "@babel/highlight": "^7.10.4"
+      }
+    },
+    "node_modules/@gorhom/bottom-sheet": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@gorhom/bottom-sheet/-/bottom-sheet-5.2.8.tgz",
+      "integrity": "sha512-+N27SMpbBxXZQ/IA2nlEV6RGxL/qSFHKfdFKcygvW+HqPG5jVNb1OqehLQsGfBP+Up42i0gW5ppI+DhpB7UCzA==",
+      "license": "MIT",
+      "dependencies": {
+        "@gorhom/portal": "1.0.14",
+        "invariant": "^2.2.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-native": "*",
+        "react": "*",
+        "react-native": "*",
+        "react-native-gesture-handler": ">=2.16.1",
+        "react-native-reanimated": ">=3.16.0 || >=4.0.0-"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@gorhom/portal": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/@gorhom/portal/-/portal-1.0.14.tgz",
+      "integrity": "sha512-MXyL4xvCjmgaORr/rtryDNFy3kU4qUbKlwtQqqsygd0xX3mhKjOLn6mQK8wfu0RkoE0pBE0nAasRoHua+/QZ7A==",
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.1"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/@humanfs/core": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@expo/vector-icons": "^15.0.3",
+    "@gorhom/bottom-sheet": "^5.2.8",
     "@react-navigation/bottom-tabs": "^7.4.0",
     "@react-navigation/elements": "^2.6.3",
     "@react-navigation/native": "^7.1.8",

--- a/screens/feed/components/my-feed-contents/index.tsx
+++ b/screens/feed/components/my-feed-contents/index.tsx
@@ -1,13 +1,20 @@
 import { router } from "expo-router";
-import { ScrollView, StyleSheet, View } from "react-native";
+import { useState } from "react";
+import { Pressable, ScrollView, StyleSheet, View } from "react-native";
 import Toast from "react-native-toast-message";
 
-import { AppText, CustomButton, CustomModal } from "@shared/ui";
+import {
+  AppText,
+  CustomBottomSheet,
+  CustomButton,
+  CustomModal,
+} from "@shared/ui";
 import { colors } from "@theme/token";
-import { useState } from "react";
 
 export default function MyFeedContents() {
   const [isModalVisible, setIsModalVisible] = useState(false);
+  const [isBottomSheetVisible, setIsBottomSheetVisible] = useState(false);
+
   // TODO: 토스트 메시지 테스트용. 삭제 예정
   const handleShowToastTest = () => {
     Toast.show({
@@ -24,6 +31,15 @@ export default function MyFeedContents() {
   const handleCloseModal = () => {
     setIsModalVisible(false);
   };
+
+  // TODO: 바텀시트 컴포넌트 테스트용
+  const handleOpenBottomSheet = () => {
+    setIsBottomSheetVisible(true);
+  };
+  const handleCloseBottomSheet = () => {
+    setIsBottomSheetVisible(false);
+  };
+
   return (
     <ScrollView contentContainerStyle={styles.content}>
       <AppText
@@ -58,7 +74,7 @@ export default function MyFeedContents() {
         weight="extrabold"
         size="lg"
         color={colors.purple.sub}
-        onPress={handleShowToastTest}
+        onPress={handleOpenBottomSheet}
       >
         바텀시트
       </AppText>
@@ -105,6 +121,30 @@ export default function MyFeedContents() {
           </View>
         </View>
       </CustomModal>
+      <CustomBottomSheet
+        isVisible={isBottomSheetVisible}
+        handleClose={handleCloseBottomSheet}
+      >
+        <View style={styles.bottomSheetContentWrapper}>
+          <Pressable
+            style={styles.bottomSheetButton}
+            onPress={() => console.log("수정하기")}
+          >
+            <AppText weight="medium" size="base" color={colors.white}>
+              수정하기
+            </AppText>
+          </Pressable>
+          <View style={styles.bottomSheetDivider} />
+          <Pressable
+            style={styles.bottomSheetButton}
+            onPress={() => console.log("삭제하기")}
+          >
+            <AppText weight="medium" size="base" color={colors.red}>
+              삭제하기
+            </AppText>
+          </Pressable>
+        </View>
+      </CustomBottomSheet>
     </ScrollView>
   );
 }
@@ -121,5 +161,20 @@ const styles = StyleSheet.create({
   modalButtonWrapper: {
     flexDirection: "row",
     gap: 20,
+  },
+
+  // TODO: 바텀시트 테스트용. 삭제 예정
+  bottomSheetContentWrapper: {
+    gap: 8,
+  },
+  bottomSheetDivider: {
+    backgroundColor: "#525252",
+    width: "100%",
+    height: 1,
+  },
+  bottomSheetButton: {
+    paddingHorizontal: 12,
+    height: 50,
+    justifyContent: "center",
   },
 });

--- a/src/shared/ui/custom-bottom-sheet/index.tsx
+++ b/src/shared/ui/custom-bottom-sheet/index.tsx
@@ -1,0 +1,85 @@
+﻿import {
+  BottomSheetBackdrop,
+  BottomSheetModal,
+  BottomSheetView,
+} from "@gorhom/bottom-sheet";
+import { BlurView } from "expo-blur";
+import { ReactNode, useEffect, useRef } from "react";
+import { StyleSheet } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+
+import { colors } from "@theme/token";
+
+interface CustomBottomSheetProps {
+  children: ReactNode;
+  isVisible: boolean;
+  handleClose: () => void;
+}
+
+export default function CustomBottomSheet({
+  children,
+  isVisible,
+  handleClose,
+}: CustomBottomSheetProps) {
+  const bottomSheetRef = useRef<BottomSheetModal>(null);
+  const insets = useSafeAreaInsets();
+
+  useEffect(() => {
+    if (isVisible) {
+      bottomSheetRef.current?.present();
+      return;
+    }
+
+    bottomSheetRef.current?.dismiss();
+  }, [isVisible]);
+
+  return (
+    <BottomSheetModal
+      ref={bottomSheetRef}
+      onDismiss={handleClose}
+      enableDynamicSizing
+      enablePanDownToClose
+      backdropComponent={(props) => (
+        <>
+          {/* TODO: 블러가 좀 늦게 사라지는 현상 추후 논의 필요 */}
+          <BlurView
+            intensity={15}
+            tint="dark"
+            style={[styles.backdrop, !isVisible && { display: "none" }]}
+            pointerEvents="none"
+          />
+          <BottomSheetBackdrop
+            {...props}
+            appearsOnIndex={0}
+            disappearsOnIndex={-1}
+            pressBehavior="close"
+          />
+        </>
+      )}
+      backgroundStyle={styles.sheetBackground}
+      handleComponent={null}
+    >
+      <BottomSheetView
+        style={[styles.contentContainer, { paddingBottom: 20 + insets.bottom }]}
+      >
+        {children}
+      </BottomSheetView>
+    </BottomSheetModal>
+  );
+}
+
+const styles = StyleSheet.create({
+  sheetBackground: {
+    borderTopLeftRadius: 12,
+    borderTopRightRadius: 12,
+    backgroundColor: colors.darkgrey.main,
+  },
+  backdrop: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: "rgba(18, 18, 18, 0.30)",
+  },
+  contentContainer: {
+    flex: 1,
+    padding: 20,
+  },
+});

--- a/src/shared/ui/index.ts
+++ b/src/shared/ui/index.ts
@@ -1,6 +1,7 @@
 export { default as AppText } from "./app-text";
 export { default as BookInfoBar } from "./book-info-bar";
 export { ButtonHeader, CustomButton, SelectChip } from "./button";
+export { default as CustomBottomSheet } from "./custom-bottom-sheet";
 export { default as CustomHeader } from "./custom-header";
 export { default as CustomModal } from "./custom-modal";
 export { default as CustomSwitch } from "./custom-switch";


### PR DESCRIPTION
## 📌 Related Issues

- close #4 

## 📄 Tasks

- `@gorhom/bottom-sheet` 라이브러리 설치
- `app/_layout.tsx` 에 GestureHandlerRootView와 BottomSheetModalProvider 추가
- CustomBottomSheet 구현
  - children, isVisible, handleClose 를 props로 받음
  - 모달과 같이 isVisible로 상태 제어
  - 필요한 페이지, 컴포넌트 등에서 CustomBottomSheet를 사용하여 알맞는 바텀시트 구현

## 📷 Screenshot

<img width="450" height="797" alt="image" src="https://github.com/user-attachments/assets/9bec1cd0-66f0-4762-bd5a-93ac7e0aa6aa" />

## 🔔 ETC

- 바텀시트가 닫힐 때, 블러가 조금 늦게 사라지는 현상이 있는데 어떻게 처리할지 논의가 필요합니다.
  - 바텀시트가 완전히 내려간 이후(애니메이션 이후) 언마운트 되기 때문에 늦게 닫힘
  1. 블러 제거
  2. animatedIndex 활용하여 블러를 커스텀하여 즉시 사라지도록 구현


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 피드에서 게시물 관리를 위한 바텀시트 UI 추가 (수정, 삭제 옵션)
  * 터치 제스처 및 바텀시트 모달 기능 지원

* **개선사항**
  * 앱 레이아웃 구조 개선으로 더 나은 모달 처리 지원

<!-- end of auto-generated comment: release notes by coderabbit.ai -->