### PR TITLE
[Refactor/#17] 댓글 신고, 삭제 바텀시트로 변경

### DIFF
--- a/screens/feed-detail/components/feed-detail-bottom-sheet/index.tsx
+++ b/screens/feed-detail/components/feed-detail-bottom-sheet/index.tsx
@@ -1,7 +1,6 @@
 import { Pressable, StyleSheet, View } from "react-native";
 
-import AppText from "@shared/ui/app-text";
-import CustomBottomSheet from "@shared/ui/custom-bottom-sheet";
+import { AppText, CustomBottomSheet } from "@shared/ui";
 import { colors } from "@theme/token";
 
 // TODO: 추후 api 연동 시 수정
@@ -31,20 +30,20 @@ export default function FeedDetailBottomSheet({
         <View style={styles.bottomSheetContentWrapper}>
           <Pressable style={styles.bottomSheetButton} onPress={handleToEdit}>
             <AppText weight="medium" size="base" color={colors.white}>
-              수정하기
+              피드 수정하기
             </AppText>
           </Pressable>
           <View style={styles.bottomSheetDivider} />
           <Pressable style={styles.bottomSheetButton} onPress={handleDelete}>
             <AppText weight="medium" size="base" color={colors.red}>
-              삭제하기
+              피드 삭제하기
             </AppText>
           </Pressable>
         </View>
       ) : (
         <Pressable style={styles.bottomSheetButton} onPress={handleReport}>
           <AppText weight="medium" size="base" color={colors.red}>
-            신고하기
+            피드 신고하기
           </AppText>
         </Pressable>
       )}

--- a/src/shared/ui/comment-list/comment-bottom-sheet.tsx
+++ b/src/shared/ui/comment-list/comment-bottom-sheet.tsx
@@ -1,0 +1,63 @@
+import { Pressable, StyleSheet } from "react-native";
+
+import { colors } from "@theme/token";
+
+import AppText from "../app-text";
+import CustomBottomSheet from "../custom-bottom-sheet";
+
+interface CommentBottomSheetProps {
+  commentId: number;
+  isWriter: boolean;
+  isVisible: boolean;
+  handleCloseBottomSheet: () => void;
+}
+
+export default function CommentBottomSheet({
+  commentId,
+  isWriter,
+  isVisible,
+  handleCloseBottomSheet,
+}: CommentBottomSheetProps) {
+  const handlePressButton = () => {
+    if (isWriter) {
+      console.log(commentId, "번 댓글 삭제");
+      handleCloseBottomSheet();
+    } else {
+      console.log(commentId, "번 댓글 신고");
+      handleCloseBottomSheet();
+    }
+  };
+
+  return (
+    <CustomBottomSheet
+      isVisible={isVisible}
+      handleClose={handleCloseBottomSheet}
+    >
+      <Pressable style={styles.bottomSheetButton} onPress={handlePressButton}>
+        <AppText
+          weight="medium"
+          size="base"
+          color={isWriter ? colors.white : colors.red}
+        >
+          {isWriter ? "댓글 삭제하기" : "댓글 신고하기"}
+        </AppText>
+      </Pressable>
+    </CustomBottomSheet>
+  );
+}
+
+const styles = StyleSheet.create({
+  bottomSheetContentWrapper: {
+    gap: 8,
+  },
+  bottomSheetDivider: {
+    backgroundColor: "#525252",
+    width: "100%",
+    height: 1,
+  },
+  bottomSheetButton: {
+    paddingHorizontal: 12,
+    height: 50,
+    justifyContent: "center",
+  },
+});

--- a/src/shared/ui/comment-list/comment-item.tsx
+++ b/src/shared/ui/comment-list/comment-item.tsx
@@ -1,11 +1,12 @@
-import { Modal, Pressable, StyleSheet, View } from "react-native";
+import { useRef, useState } from "react";
+import { Pressable, StyleSheet, View } from "react-native";
 
 import { IcHeart, IcHeartFilled, IcReply } from "@images/icons";
 import { colors } from "@theme/token";
 
-import { useRef, useState } from "react";
 import AppText from "../app-text";
 import ProfileImage from "../profile-image";
+import CommentBottomSheet from "./comment-bottom-sheet";
 import { CommentListType, CommentReplyListType } from "./types";
 
 interface CommentItemProps {
@@ -17,8 +18,7 @@ export default function CommentItem({
   comment,
   handlePressReply,
 }: CommentItemProps) {
-  const [isModalVisible, setIsModalVisible] = useState(false);
-  const [modalPositionY, setModalPositionY] = useState(0);
+  const [isBottomSheetVisible, setIsBottomSheetVisible] = useState(false);
   const commentItemRef = useRef<View>(null);
 
   const handleToUser = () => {
@@ -32,22 +32,10 @@ export default function CommentItem({
   };
 
   const handleLongPressComment = () => {
-    commentItemRef.current?.measureInWindow((_, y) => {
-      setModalPositionY(y + 50);
-      setIsModalVisible(true);
-    });
+    setIsBottomSheetVisible(true);
   };
-  const handleCloseModal = () => {
-    setIsModalVisible(false);
-  };
-  const handlePressModalButton = () => {
-    if (comment.isWriter) {
-      console.log(comment.commentId, "번 댓글 삭제");
-      setIsModalVisible(false);
-    } else {
-      console.log(comment.commentId, "번 댓글 신고");
-      setIsModalVisible(false);
-    }
+  const handleCloseBottomSheet = () => {
+    setIsBottomSheetVisible(false);
   };
 
   const renderContents = () => {
@@ -113,22 +101,12 @@ export default function CommentItem({
             </AppText>
           </View>
         </View>
-        <Modal
-          transparent
-          visible={isModalVisible}
-          onRequestClose={handleCloseModal}
-        >
-          <Pressable style={styles.backdrop} onPress={handleCloseModal}>
-            <Pressable
-              style={[styles.modalButton, { top: modalPositionY }]}
-              onPress={handlePressModalButton}
-            >
-              <AppText color={comment.isWriter ? colors.white : colors.red}>
-                {comment.isWriter ? "삭제하기" : "신고하기"}
-              </AppText>
-            </Pressable>
-          </Pressable>
-        </Modal>
+        <CommentBottomSheet
+          commentId={comment.commentId}
+          isWriter={comment.isWriter}
+          isVisible={isBottomSheetVisible}
+          handleCloseBottomSheet={handleCloseBottomSheet}
+        />
       </Pressable>
     );
   };


### PR DESCRIPTION
## 📌 Related Issues

- close #17 

## 📄 Tasks

- 기존에 모달로 구현하였던 댓글 신고, 삭제 버튼을 바텀시트로 변경함
- `CommentBottomSheet` 컴포넌트 구현

## 📷 Screenshot

<img width="401" height="703" alt="image" src="https://github.com/user-attachments/assets/9583b3a7-aa08-4b49-9c55-8c1b071c3fd8" />
<img width="410" height="720" alt="image" src="https://github.com/user-attachments/assets/7cc644c8-f80a-40cc-96bd-54a476aac8d1" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved comment interaction interface with clearer action options based on user permissions (edit/delete for your comments, report for others).

* **UI/UX Improvements**
  * Feed action labels now display more descriptive text for edit, delete, and report functions.
  * Replaced modal-based interaction pattern with bottom sheet interface for comment actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->