### PR TITLE
[Feature/#88] 회원가입 api 연동

### DIFF
--- a/app/sign-up/(profile)/_layout.tsx
+++ b/app/sign-up/(profile)/_layout.tsx
@@ -1,7 +1,10 @@
 import { Stack } from "expo-router";
 
-import { SignUpHeader } from "@screens/sign-up/components";
-import { NicknameGenreContext, useSignUpProfile } from "@screens/sign-up/hooks";
+import {
+  NicknameGenreContext,
+  SignUpHeader,
+  useSignUpProfile,
+} from "@screens/sign-up";
 import { colors } from "@theme/token";
 
 export default function NicknameGenreLayout() {
@@ -13,7 +16,7 @@ export default function NicknameGenreLayout() {
     setGenre,
     disabledNickname,
     handleCheckNickname,
-    handleToOnboarding,
+    handleSignupAndToOnboarding,
   } = useSignUpProfile();
 
   return (
@@ -44,7 +47,7 @@ export default function NicknameGenreLayout() {
               <SignUpHeader
                 step={2}
                 disabled={!genre}
-                handleClickNext={handleToOnboarding}
+                handleClickNext={handleSignupAndToOnboarding}
               />
             ),
           }}

--- a/app/sign-up/(profile)/_layout.tsx
+++ b/app/sign-up/(profile)/_layout.tsx
@@ -17,6 +17,8 @@ export default function NicknameGenreLayout() {
     disabledNickname,
     handleCheckNickname,
     handleSignupAndToOnboarding,
+    isPendingCheckNickname,
+    isPendingSignup,
   } = useSignUpProfile();
 
   return (
@@ -34,7 +36,7 @@ export default function NicknameGenreLayout() {
             header: () => (
               <SignUpHeader
                 step={1}
-                disabled={disabledNickname}
+                disabled={disabledNickname || isPendingCheckNickname}
                 handleClickNext={handleCheckNickname}
               />
             ),
@@ -46,7 +48,7 @@ export default function NicknameGenreLayout() {
             header: () => (
               <SignUpHeader
                 step={2}
-                disabled={!genre}
+                disabled={!genre || isPendingSignup}
                 handleClickNext={handleSignupAndToOnboarding}
               />
             ),

--- a/app/sign-up/(profile)/_layout.tsx
+++ b/app/sign-up/(profile)/_layout.tsx
@@ -12,7 +12,7 @@ export default function NicknameGenreLayout() {
     genre,
     setGenre,
     disabledNickname,
-    handleToSelectGenre,
+    handleCheckNickname,
     handleToOnboarding,
   } = useSignUpProfile();
 
@@ -32,7 +32,7 @@ export default function NicknameGenreLayout() {
               <SignUpHeader
                 step={1}
                 disabled={disabledNickname}
-                handleClickNext={handleToSelectGenre}
+                handleClickNext={handleCheckNickname}
               />
             ),
           }}

--- a/screens/sign-up/hooks/use-sign-up-profile.ts
+++ b/screens/sign-up/hooks/use-sign-up-profile.ts
@@ -9,19 +9,21 @@ import {
 
 export const useSignUpProfile = () => {
   // TODO: isPendingCheckNickname, isErrorCheckNickname, checkNicknameError는 추후 로딩 및 에러 처리 추가
-  const { checkNickname } = useCheckNicknameMutation();
+  const { checkNickname, isPendingCheckNickname } = useCheckNicknameMutation();
   // TODO: isPendingSignup, isErrorSignup, signupError 추후 추가
-  const { signup } = useSignupMutation();
+  const { signup, isPendingSignup } = useSignupMutation();
 
   const [nickname, setNickname] = useState("");
   const [isNicknameDuplicated, setIsNicknameDuplicated] = useState(false);
   const [genre, setGenre] = useState<string | null>(null);
 
   const disabledNickname = nickname.trim().length < 2;
+  const normalizedNickname = nickname.trim();
 
   const handleCheckNickname = () => {
+    if (isPendingCheckNickname) return;
     checkNickname(
-      { nickname },
+      { nickname: normalizedNickname },
       {
         onError: () => alert("네트워크 오류 발생. 다시 시도해주세요."),
         onSuccess: (data: CheckNicknameResponse) => {
@@ -37,8 +39,8 @@ export const useSignUpProfile = () => {
   };
 
   const handleSignupAndToOnboarding = () => {
-    if (!genre) return null;
-    signup({ aliasName: genre, nickname });
+    if (!genre || isPendingSignup) return;
+    signup({ aliasName: genre, nickname: normalizedNickname });
   };
 
   return {
@@ -50,5 +52,7 @@ export const useSignUpProfile = () => {
     disabledNickname,
     handleCheckNickname,
     handleSignupAndToOnboarding,
+    isPendingCheckNickname,
+    isPendingSignup,
   };
 };

--- a/screens/sign-up/hooks/use-sign-up-profile.ts
+++ b/screens/sign-up/hooks/use-sign-up-profile.ts
@@ -1,11 +1,17 @@
 import { router } from "expo-router";
 import { useState } from "react";
 
-import { CheckNicknameResponse, useCheckNicknameMutation } from "@apis/user";
+import {
+  CheckNicknameResponse,
+  useCheckNicknameMutation,
+  useSignupMutation,
+} from "@apis/user";
 
 export const useSignUpProfile = () => {
   // TODO: isPendingCheckNickname, isErrorCheckNickname, checkNicknameError는 추후 로딩 및 에러 처리 추가
   const { checkNickname } = useCheckNicknameMutation();
+  // TODO: isPendingSignup, isErrorSignup, signupError 추후 추가
+  const { signup } = useSignupMutation();
 
   const [nickname, setNickname] = useState("");
   const [isNicknameDuplicated, setIsNicknameDuplicated] = useState(false);
@@ -30,10 +36,9 @@ export const useSignUpProfile = () => {
     );
   };
 
-  // TODO: 서버에 회원가입 요청
-  const handleToOnboarding = () => {
-    alert(`닉네임: ${nickname} / 장르: ${genre}`);
-    router.replace("/sign-up/onboarding");
+  const handleSignupAndToOnboarding = () => {
+    if (!genre) return null;
+    signup({ aliasName: genre, nickname });
   };
 
   return {
@@ -44,6 +49,6 @@ export const useSignUpProfile = () => {
     setGenre,
     disabledNickname,
     handleCheckNickname,
-    handleToOnboarding,
+    handleSignupAndToOnboarding,
   };
 };

--- a/screens/sign-up/hooks/use-sign-up-profile.ts
+++ b/screens/sign-up/hooks/use-sign-up-profile.ts
@@ -1,17 +1,33 @@
 import { router } from "expo-router";
 import { useState } from "react";
 
+import { CheckNicknameResponse, useCheckNicknameMutation } from "@apis/user";
+
 export const useSignUpProfile = () => {
+  // TODO: isPendingCheckNickname은 추후 로딩 페이지 및 로딩 관련 처리 적용 시 추가
+  const { checkNickname } = useCheckNicknameMutation();
+
   const [nickname, setNickname] = useState("");
   const [isNicknameDuplicated, setIsNicknameDuplicated] = useState(false);
   const [genre, setGenre] = useState<string | null>(null);
 
   const disabledNickname = nickname.trim().length < 2;
 
-  // TODO: 중복 여부는 추후 서버 api와 연동하여 판별. 성공 시 이동
-  const handleToSelectGenre = () => {
-    setIsNicknameDuplicated(false);
-    router.push("/sign-up/genre");
+  const handleCheckNickname = () => {
+    checkNickname(
+      { nickname },
+      {
+        onError: () => alert("네트워크 오류 발생. 다시 시도해주세요."),
+        onSuccess: (data: CheckNicknameResponse) => {
+          if (data.isVerified) {
+            setIsNicknameDuplicated(false);
+            router.push("/sign-up/genre");
+          } else {
+            setIsNicknameDuplicated(true);
+          }
+        },
+      },
+    );
   };
 
   // TODO: 서버에 회원가입 요청
@@ -27,7 +43,7 @@ export const useSignUpProfile = () => {
     genre,
     setGenre,
     disabledNickname,
-    handleToSelectGenre,
+    handleCheckNickname,
     handleToOnboarding,
   };
 };

--- a/screens/sign-up/hooks/use-sign-up-profile.ts
+++ b/screens/sign-up/hooks/use-sign-up-profile.ts
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { CheckNicknameResponse, useCheckNicknameMutation } from "@apis/user";
 
 export const useSignUpProfile = () => {
-  // TODO: isPendingCheckNickname은 추후 로딩 페이지 및 로딩 관련 처리 적용 시 추가
+  // TODO: isPendingCheckNickname, isErrorCheckNickname, checkNicknameError는 추후 로딩 및 에러 처리 추가
   const { checkNickname } = useCheckNicknameMutation();
 
   const [nickname, setNickname] = useState("");

--- a/screens/sign-up/index.ts
+++ b/screens/sign-up/index.ts
@@ -1,0 +1,2 @@
+export { SignUpHeader } from "./components";
+export { NicknameGenreContext, useSignUpProfile } from "./hooks";

--- a/screens/sign-up/welcome/welcome-screen.tsx
+++ b/screens/sign-up/welcome/welcome-screen.tsx
@@ -1,19 +1,15 @@
 import { router } from "expo-router";
 import { useCallback } from "react";
-import { Pressable, StyleSheet, View } from "react-native";
+import { Image, Pressable, StyleSheet, View } from "react-native";
 
+import { useGetUserInfoQuery } from "@apis/user";
 import { IcArrowLeft } from "@images/icons";
 import { AppText, CustomButton, CustomHeader } from "@shared/ui";
-import { GENRES } from "@shared/ui/genre-card-group/constants";
 import { colors } from "@theme/token";
 
-// TODO: 서버에서 사용자 닉네임, 장르 가져오기
-const nickname = "Username01";
-const genre = "철학자";
-const profileColor = colors.character.orange;
-
 export default function WelcomeScreen() {
-  const GenreImage = GENRES.find((item) => item.subTitle === genre)?.image;
+  // TODO: 추후 로딩 및 예외처리 isPendingUserInfo, isErrorUserInfo, userInfoError
+  const { userInfo } = useGetUserInfoQuery();
 
   const handleGoBack = useCallback(() => {
     router.back();
@@ -35,7 +31,7 @@ export default function WelcomeScreen() {
       <View style={styles.container}>
         <View style={styles.textWrapper}>
           <AppText weight="bold" size="xl" color={colors.white}>
-            안녕하세요, {nickname}님
+            안녕하세요, {userInfo?.nickname}님
           </AppText>
           <AppText weight="medium" size="sm" color={colors.white}>
             이제 Thip에서 활동할 준비를 모두 마쳤어요!
@@ -43,16 +39,18 @@ export default function WelcomeScreen() {
         </View>
         <View style={styles.content}>
           <View style={styles.profileContainer}>
-            {/* TODO: 이미지 관련 스타일링 디테일 확인 */}
-            <View style={styles.image}>
-              {GenreImage && <GenreImage width={43} height={43} />}
+            <View style={styles.imageContainer}>
+              <Image
+                style={styles.image}
+                source={{ uri: userInfo?.profileImageUrl }}
+              />
             </View>
             <View style={styles.profileWrapper}>
               <AppText weight="semibold" size="lg" color={colors.white}>
-                {nickname}
+                {userInfo?.nickname}
               </AppText>
-              <AppText weight="regular" size="sm" color={profileColor}>
-                {genre}
+              <AppText weight="regular" size="sm" color={userInfo?.aliasColor}>
+                {userInfo?.aliasName}
               </AppText>
             </View>
           </View>
@@ -87,7 +85,7 @@ const styles = StyleSheet.create({
     gap: 8,
     alignItems: "center",
   },
-  image: {
+  imageContainer: {
     width: 54,
     height: 54,
     justifyContent: "flex-end",
@@ -96,6 +94,10 @@ const styles = StyleSheet.create({
     borderWidth: 0.5,
     borderColor: colors.grey[200],
     overflow: "hidden",
+  },
+  image: {
+    width: 54,
+    height: 54,
   },
   profileWrapper: {
     alignItems: "center",

--- a/src/apis/endpoint.ts
+++ b/src/apis/endpoint.ts
@@ -7,6 +7,7 @@ export const USER_URL = {
   NICKNAME: "/users/nickname",
   ALIAS_LIST: "/users/alias",
   SIGNUP: "/users/signup",
+  USER_INFO: "/users/my-page",
 } as const;
 
 export const FEED_URL = {} as const;

--- a/src/apis/endpoint.ts
+++ b/src/apis/endpoint.ts
@@ -5,7 +5,7 @@ export const AUTH_URL = {
 export const USER_URL = {
   DEFAULT: "/users",
   NICKNAME: "/users/nickname",
-  ALIAS: "/users/alias",
+  ALIAS_LIST: "/users/alias",
   SIGNUP: "/users/signup",
 } as const;
 

--- a/src/apis/endpoint.ts
+++ b/src/apis/endpoint.ts
@@ -2,4 +2,11 @@ export const AUTH_URL = {
   LOGIN: "/auth/users",
 } as const;
 
+export const USER_URL = {
+  DEFAULT: "/users",
+  NICKNAME: "/users/nickname",
+  ALIAS: "/users/alias",
+  SIGNUP: "/users/signup",
+} as const;
+
 export const FEED_URL = {} as const;

--- a/src/apis/user/index.ts
+++ b/src/apis/user/index.ts
@@ -1,0 +1,18 @@
+export { checkNicknameApi, getAliasListApi, signupApi } from "./user.api";
+
+export {
+  useCheckNicknameMutation,
+  useGetAliasListQuery,
+  useSignupMutation,
+} from "./user.queries";
+
+export {
+  AliasChoiceType,
+  CheckNicknameRequest,
+  CheckNicknameResponse,
+  GetAliasListResponse,
+  SignupRequest,
+  SignupResponse,
+} from "./user.types";
+
+export {} from "./user.query-key";

--- a/src/apis/user/index.ts
+++ b/src/apis/user/index.ts
@@ -6,7 +6,7 @@ export {
   useSignupMutation,
 } from "./user.queries";
 
-export {
+export type {
   AliasChoiceType,
   CheckNicknameRequest,
   CheckNicknameResponse,

--- a/src/apis/user/index.ts
+++ b/src/apis/user/index.ts
@@ -15,4 +15,4 @@ export {
   SignupResponse,
 } from "./user.types";
 
-export {} from "./user.query-key";
+export { USER_QUERY_KEY } from "./user.query-key";

--- a/src/apis/user/index.ts
+++ b/src/apis/user/index.ts
@@ -1,8 +1,14 @@
-export { checkNicknameApi, getAliasListApi, signupApi } from "./user.api";
+export {
+  checkNicknameApi,
+  getAliasListApi,
+  getUserInfoApi,
+  signupApi,
+} from "./user.api";
 
 export {
   useCheckNicknameMutation,
   useGetAliasListQuery,
+  useGetUserInfoQuery,
   useSignupMutation,
 } from "./user.queries";
 
@@ -11,6 +17,7 @@ export type {
   CheckNicknameRequest,
   CheckNicknameResponse,
   GetAliasListResponse,
+  GetUserInfoResponse,
   SignupRequest,
   SignupResponse,
 } from "./user.types";

--- a/src/apis/user/user.api.ts
+++ b/src/apis/user/user.api.ts
@@ -1,0 +1,17 @@
+import { apiClient } from "@apis/api-client";
+import { USER_URL } from "@apis/endpoint";
+
+import type { CheckNicknameRequest, CheckNicknameResponse } from "./user.types";
+
+export const checkNicknameApi = async (body: CheckNicknameRequest) => {
+  const response = await apiClient.post<
+    CheckNicknameResponse,
+    CheckNicknameRequest
+  >(USER_URL.NICKNAME, body);
+
+  return response.data;
+};
+
+export const getAliasListApi = async () => {};
+
+export const signupApi = async () => {};

--- a/src/apis/user/user.api.ts
+++ b/src/apis/user/user.api.ts
@@ -5,6 +5,8 @@ import type {
   CheckNicknameRequest,
   CheckNicknameResponse,
   GetAliasListResponse,
+  SignupRequest,
+  SignupResponse,
 } from "./user.types";
 
 export const checkNicknameApi = async (body: CheckNicknameRequest) => {
@@ -24,4 +26,11 @@ export const getAliasListApi = async () => {
   return response.data;
 };
 
-export const signupApi = async () => {};
+export const signupApi = async (body: SignupRequest) => {
+  const response = await apiClient.post<SignupResponse, SignupRequest>(
+    USER_URL.SIGNUP,
+    body,
+  );
+
+  return response.data;
+};

--- a/src/apis/user/user.api.ts
+++ b/src/apis/user/user.api.ts
@@ -5,6 +5,7 @@ import type {
   CheckNicknameRequest,
   CheckNicknameResponse,
   GetAliasListResponse,
+  GetUserInfoResponse,
   SignupRequest,
   SignupResponse,
 } from "./user.types";
@@ -31,6 +32,12 @@ export const signupApi = async (body: SignupRequest) => {
     USER_URL.SIGNUP,
     body,
   );
+
+  return response.data;
+};
+
+export const getUserInfoApi = async () => {
+  const response = await apiClient.get<GetUserInfoResponse>(USER_URL.USER_INFO);
 
   return response.data;
 };

--- a/src/apis/user/user.api.ts
+++ b/src/apis/user/user.api.ts
@@ -1,7 +1,11 @@
 import { apiClient } from "@apis/api-client";
 import { USER_URL } from "@apis/endpoint";
 
-import type { CheckNicknameRequest, CheckNicknameResponse } from "./user.types";
+import type {
+  CheckNicknameRequest,
+  CheckNicknameResponse,
+  GetAliasListResponse,
+} from "./user.types";
 
 export const checkNicknameApi = async (body: CheckNicknameRequest) => {
   const response = await apiClient.post<
@@ -12,6 +16,12 @@ export const checkNicknameApi = async (body: CheckNicknameRequest) => {
   return response.data;
 };
 
-export const getAliasListApi = async () => {};
+export const getAliasListApi = async () => {
+  const response = await apiClient.get<GetAliasListResponse>(
+    USER_URL.ALIAS_LIST,
+  );
+
+  return response.data;
+};
 
 export const signupApi = async () => {};

--- a/src/apis/user/user.queries.ts
+++ b/src/apis/user/user.queries.ts
@@ -1,26 +1,52 @@
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 
-import { checkNicknameApi } from "./user.api";
-import type { CheckNicknameRequest, CheckNicknameResponse } from "./user.types";
+import { checkNicknameApi, getAliasListApi } from "./user.api";
+import { USER_QUERY_KEY } from "./user.query-key";
+import type {
+  CheckNicknameRequest,
+  CheckNicknameResponse,
+  GetAliasListResponse,
+} from "./user.types";
 
 export const useCheckNicknameMutation = () => {
-  const { mutate: checkNickname, isPending: isPendingCheckNickname } =
-    useMutation<CheckNicknameResponse, Error, CheckNicknameRequest>({
-      mutationFn: checkNicknameApi,
-      onError: (error) => {
-        console.error(
-          "[useCheckNicknameMutation] check nickname failed",
-          error,
-        );
-      },
-    });
+  const {
+    mutate: checkNickname,
+    isPending: isPendingCheckNickname,
+    isError: isErrorCheckNickname,
+    error: checkNicknameError,
+  } = useMutation<CheckNicknameResponse, Error, CheckNicknameRequest>({
+    mutationFn: checkNicknameApi,
+    onError: (error) => {
+      console.error("[useCheckNicknameMutation] check nickname failed", error);
+    },
+  });
 
   return {
     checkNickname,
     isPendingCheckNickname,
+    isErrorCheckNickname,
+    checkNicknameError,
   };
 };
 
-export const useGetAliasListQuery = () => {};
+// TODO: 서버에서 보내주는 이미지에 문제가 있어서 추후 수정한 뒤 연동
+export const useGetAliasListQuery = () => {
+  const {
+    data: aliasList,
+    isPending: isPendingAliasList,
+    isError: isErrorAliasList,
+    error: aliasListError,
+  } = useQuery<GetAliasListResponse, Error>({
+    queryKey: USER_QUERY_KEY.ALIAS_LIST,
+    queryFn: getAliasListApi,
+  });
+
+  return {
+    aliasList: aliasList?.aliasChoices ?? [],
+    isPendingAliasList,
+    isErrorAliasList,
+    aliasListError,
+  };
+};
 
 export const useSignupMutation = () => {};

--- a/src/apis/user/user.queries.ts
+++ b/src/apis/user/user.queries.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { router } from "expo-router";
+import Toast from "react-native-toast-message";
 
 import { setAuthToken } from "../token-storage";
 import { checkNicknameApi, getAliasListApi, signupApi } from "./user.api";
@@ -63,12 +64,24 @@ export const useSignupMutation = () => {
   } = useMutation<SignupResponse, Error, SignupRequest>({
     mutationFn: signupApi,
     onSuccess: async (data) => {
-      await setAuthToken(data.accessToken);
-      router.replace("/sign-up/onboarding");
+      try {
+        await setAuthToken(data.accessToken);
+        router.replace("/sign-up/onboarding");
+      } catch {
+        console.error("[useSignupMutation] token persist failed");
+        Toast.show({
+          type: "error",
+          text1: "인증 토큰 저장에 실패했어요. 다시 시도해주세요.",
+        });
+      }
     },
     // TODO: 예외처리 UI 추가
     onError: (error) => {
       console.error("[useSignupMutation] signup failed", error);
+      Toast.show({
+        type: "error",
+        text1: "회원 가입에 실패했어요. 다시 시도해주세요.",
+      });
     },
   });
 

--- a/src/apis/user/user.queries.ts
+++ b/src/apis/user/user.queries.ts
@@ -1,0 +1,26 @@
+import { useMutation } from "@tanstack/react-query";
+
+import { checkNicknameApi } from "./user.api";
+import type { CheckNicknameRequest, CheckNicknameResponse } from "./user.types";
+
+export const useCheckNicknameMutation = () => {
+  const { mutate: checkNickname, isPending: isPendingCheckNickname } =
+    useMutation<CheckNicknameResponse, Error, CheckNicknameRequest>({
+      mutationFn: checkNicknameApi,
+      onError: (error) => {
+        console.error(
+          "[useCheckNicknameMutation] check nickname failed",
+          error,
+        );
+      },
+    });
+
+  return {
+    checkNickname,
+    isPendingCheckNickname,
+  };
+};
+
+export const useGetAliasListQuery = () => {};
+
+export const useSignupMutation = () => {};

--- a/src/apis/user/user.queries.ts
+++ b/src/apis/user/user.queries.ts
@@ -3,12 +3,18 @@ import { router } from "expo-router";
 import Toast from "react-native-toast-message";
 
 import { setAuthToken } from "../token-storage";
-import { checkNicknameApi, getAliasListApi, signupApi } from "./user.api";
+import {
+  checkNicknameApi,
+  getAliasListApi,
+  getUserInfoApi,
+  signupApi,
+} from "./user.api";
 import { USER_QUERY_KEY } from "./user.query-key";
 import type {
   CheckNicknameRequest,
   CheckNicknameResponse,
   GetAliasListResponse,
+  GetUserInfoResponse,
   SignupRequest,
   SignupResponse,
 } from "./user.types";
@@ -45,6 +51,8 @@ export const useGetAliasListQuery = () => {
   } = useQuery<GetAliasListResponse, Error>({
     queryKey: USER_QUERY_KEY.ALIAS_LIST,
     queryFn: getAliasListApi,
+    staleTime: 1000 * 60 * 60,
+    gcTime: 1000 * 60 * 90,
   });
 
   return {
@@ -90,5 +98,26 @@ export const useSignupMutation = () => {
     isPendingSignup,
     isErrorSignup,
     signupError,
+  };
+};
+
+export const useGetUserInfoQuery = () => {
+  const {
+    data: userInfo,
+    isPending: isPendingUserInfo,
+    isError: isErrorUserInfo,
+    error: userInfoError,
+  } = useQuery<GetUserInfoResponse, Error>({
+    queryKey: USER_QUERY_KEY.USER_INFO,
+    queryFn: getUserInfoApi,
+    staleTime: 1000 * 60 * 60,
+    gcTime: 1000 * 60 * 60,
+  });
+
+  return {
+    userInfo,
+    isPendingUserInfo,
+    isErrorUserInfo,
+    userInfoError,
   };
 };

--- a/src/apis/user/user.queries.ts
+++ b/src/apis/user/user.queries.ts
@@ -1,11 +1,15 @@
 import { useMutation, useQuery } from "@tanstack/react-query";
+import { router } from "expo-router";
 
-import { checkNicknameApi, getAliasListApi } from "./user.api";
+import { setAuthToken } from "../token-storage";
+import { checkNicknameApi, getAliasListApi, signupApi } from "./user.api";
 import { USER_QUERY_KEY } from "./user.query-key";
 import type {
   CheckNicknameRequest,
   CheckNicknameResponse,
   GetAliasListResponse,
+  SignupRequest,
+  SignupResponse,
 } from "./user.types";
 
 export const useCheckNicknameMutation = () => {
@@ -16,6 +20,7 @@ export const useCheckNicknameMutation = () => {
     error: checkNicknameError,
   } = useMutation<CheckNicknameResponse, Error, CheckNicknameRequest>({
     mutationFn: checkNicknameApi,
+    // TODO: 예외처리 UI 추가
     onError: (error) => {
       console.error("[useCheckNicknameMutation] check nickname failed", error);
     },
@@ -49,4 +54,28 @@ export const useGetAliasListQuery = () => {
   };
 };
 
-export const useSignupMutation = () => {};
+export const useSignupMutation = () => {
+  const {
+    mutate: signup,
+    isPending: isPendingSignup,
+    isError: isErrorSignup,
+    error: signupError,
+  } = useMutation<SignupResponse, Error, SignupRequest>({
+    mutationFn: signupApi,
+    onSuccess: async (data) => {
+      await setAuthToken(data.accessToken);
+      router.replace("/sign-up/onboarding");
+    },
+    // TODO: 예외처리 UI 추가
+    onError: (error) => {
+      console.error("[useSignupMutation] signup failed", error);
+    },
+  });
+
+  return {
+    signup,
+    isPendingSignup,
+    isErrorSignup,
+    signupError,
+  };
+};

--- a/src/apis/user/user.query-key.ts
+++ b/src/apis/user/user.query-key.ts
@@ -1,3 +1,4 @@
 export const USER_QUERY_KEY = {
   ALIAS_LIST: ["users", "alias-list"],
+  USER_INFO: ["users", "user-info"],
 } as const;

--- a/src/apis/user/user.query-key.ts
+++ b/src/apis/user/user.query-key.ts
@@ -1,0 +1,3 @@
+export const USER_QUERY_KEY = {
+  ALIAS_LIST: ["users", "alias-list"],
+} as const;

--- a/src/apis/user/user.types.ts
+++ b/src/apis/user/user.types.ts
@@ -26,3 +26,10 @@ export interface SignupResponse {
   userId: number;
   accessToken: string;
 }
+
+export interface GetUserInfoResponse {
+  profileImageUrl: string;
+  nickname: string;
+  aliasName: string;
+  aliasColor: string;
+}

--- a/src/apis/user/user.types.ts
+++ b/src/apis/user/user.types.ts
@@ -1,0 +1,28 @@
+export interface CheckNicknameRequest {
+  nickname: string;
+}
+
+export interface CheckNicknameResponse {
+  isVerified: boolean;
+}
+
+export interface AliasChoiceType {
+  aliasName: string;
+  categoryName: string;
+  imageUrl: string;
+  aliasColor: string;
+}
+
+export interface GetAliasListResponse {
+  aliasChoices: AliasChoiceType[];
+}
+
+export interface SignupRequest {
+  aliasName: string;
+  nickname: string;
+}
+
+export interface SignupResponse {
+  userId: number;
+  accessToken: string;
+}


### PR DESCRIPTION
## 📌 Related Issues

- close #88 

## 📄 Tasks

- 닉네임 중복 확인 api 연동
- 사용자 alias 리스트 조회 api 연동 (이것은 서버 측 이미지 이슈로 추후 페이지에 적용할 예정. 현재는 내부적으로 저장된 데이터 상수 사용)
- 회원가입 api 연동

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 닉네임 중복 확인 기능 추가(중복 시 안내)
  * 별칭(앭 내 별칭/카테고리) 선택 옵션 제공
  * 닉네임 확인 → 별칭 선택 → 온보딩으로 자연스러운 회원가입 흐름 개선
  * 닉네임/회원가입 진행 상태(로딩) 표시 및 네트워크/인증 오류 안내 Toast/알림 추가
  * 환영 화면이 실제 사용자 정보(프로필 이미지·별칭·닉네임)를 반영하여 표시
<!-- end of auto-generated comment: release notes by coderabbit.ai -->