### PR TITLE
[Feature/#93] 로그아웃 기능 추가 / 회원탈퇴, 프로필 수정 api 연동

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "android:dev": "expo run:android",
     "ios": "expo run:ios",
     "web": "expo start --web",
-    "lint": "expo lint"
+    "lint": "expo lint",
+    "test": "node --test"
   },
   "dependencies": {
     "@expo/vector-icons": "^15.0.3",

--- a/screens/(user)/edit-profile/edit-profile-screen.tsx
+++ b/screens/(user)/edit-profile/edit-profile-screen.tsx
@@ -1,36 +1,56 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { Keyboard, Pressable, StyleSheet, View } from "react-native";
 
+import {
+  useEditUserProfileMutation,
+  useGetUserInfoQuery,
+} from "@apis/user";
 import { AppText, GenreCardGroup, InputNickname } from "@shared/ui";
 import { colors } from "@theme/token";
 
 import { EditProfileHeader } from "./components";
-import {
-  DUMMY_GENRE,
-  DUMMY_NICKNAME,
-  EDIT_PROFILE_NICKNAME_ERROR,
-} from "./constants";
+import { EDIT_PROFILE_NICKNAME_ERROR } from "./constants";
 
 export default function EditProfileScreen() {
-  const [inputNickname, setInputNickname] = useState(DUMMY_NICKNAME);
-  const [selectedGenre, setSelectedGenre] = useState<string | null>(
-    DUMMY_GENRE,
-  );
+  const { userInfo } = useGetUserInfoQuery();
+  const { editUserProfile, isPendingEditUserProfile } =
+    useEditUserProfileMutation();
+  const [inputNickname, setInputNickname] = useState("");
+  const [selectedGenre, setSelectedGenre] = useState<string | null>(null);
 
   const handleUpdateProfile = () => {
-    // TODO: 서버 api 연동
-    console.log(inputNickname, selectedGenre, "로 프로필 업데이트 요청");
+    if (!userInfo || selectedGenre === null) return;
+
+    const body = {
+      ...(inputNickname !== userInfo.nickname && { nickname: inputNickname }),
+      ...(selectedGenre !== userInfo.aliasName && { aliasName: selectedGenre }),
+    };
+
+    if (Object.keys(body).length === 0) return;
+
+    editUserProfile(body);
   };
 
   const handleDismissKeyboard = useCallback(() => {
     Keyboard.dismiss();
   }, []);
 
-  // TODO: 변경사항이 있을 경우
+  useEffect(() => {
+    if (!userInfo) return;
+
+    setInputNickname(userInfo.nickname);
+    setSelectedGenre(userInfo.aliasName);
+  }, [userInfo]);
+
   const isChanged =
-    inputNickname !== DUMMY_NICKNAME || selectedGenre !== DUMMY_GENRE;
+    !!userInfo &&
+    (inputNickname !== userInfo.nickname ||
+      selectedGenre !== userInfo.aliasName);
   const ableToChange =
-    isChanged && inputNickname.length > 1 && selectedGenre !== null;
+    isChanged &&
+    inputNickname.length > 1 &&
+    selectedGenre !== null &&
+    !isPendingEditUserProfile;
 
   return (
     <Pressable onPress={handleDismissKeyboard}>

--- a/screens/(user)/edit-profile/edit-profile-screen.tsx
+++ b/screens/(user)/edit-profile/edit-profile-screen.tsx
@@ -1,10 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { Keyboard, Pressable, StyleSheet, View } from "react-native";
 
-import {
-  useEditUserProfileMutation,
-  useGetUserInfoQuery,
-} from "@apis/user";
+import { useEditUserProfileMutation, useGetUserInfoQuery } from "@apis/user";
 import { AppText, GenreCardGroup, InputNickname } from "@shared/ui";
 import { colors } from "@theme/token";
 
@@ -23,7 +20,7 @@ export default function EditProfileScreen() {
 
     const body = {
       ...(inputNickname !== userInfo.nickname && { nickname: inputNickname }),
-      ...(selectedGenre !== userInfo.aliasName && { aliasName: selectedGenre }),
+      ...{ aliasName: selectedGenre },
     };
 
     if (Object.keys(body).length === 0) return;

--- a/screens/delete-account-complete/delete-account-complete-screen.tsx
+++ b/screens/delete-account-complete/delete-account-complete-screen.tsx
@@ -1,3 +1,5 @@
+import { router } from "expo-router";
+import { useEffect } from "react";
 import { StyleSheet, useWindowDimensions, View } from "react-native";
 
 import {
@@ -12,6 +14,14 @@ import { colors } from "@theme/token";
 export default function DeleteAccountCompleteScreen() {
   const { width } = useWindowDimensions();
   const imageWidth = (width - 45) / 4;
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      router.replace("/login");
+    }, 3000);
+
+    return () => clearTimeout(timer);
+  }, []);
 
   return (
     <View style={styles.page}>

--- a/screens/delete-account/components/delete-account-modal/index.tsx
+++ b/screens/delete-account/components/delete-account-modal/index.tsx
@@ -14,9 +14,11 @@ export default function DeleteAccountModal({
   handleCloseModal,
 }: DeleteAccountModalProps) {
   // TODO: isPendingDeleteUserAccount 이용히여 추후 로딩 처리
-  const { deleteUserAccount } = useDeleteUserAccountMutation();
+  const { deleteUserAccount, isPendingDeleteUserAccount } =
+    useDeleteUserAccountMutation();
   const handleDeleteAccount = () => {
     handleCloseModal();
+    if (isPendingDeleteUserAccount) return;
     deleteUserAccount();
   };
 
@@ -44,7 +46,11 @@ export default function DeleteAccountModal({
               아니오
             </AppText>
           </CustomButton>
-          <CustomButton size="fill" handlePress={handleDeleteAccount}>
+          <CustomButton
+            size="fill"
+            handlePress={handleDeleteAccount}
+            disabled={isPendingDeleteUserAccount}
+          >
             <AppText
               weight="semibold"
               size="base"

--- a/screens/delete-account/components/delete-account-modal/index.tsx
+++ b/screens/delete-account/components/delete-account-modal/index.tsx
@@ -1,6 +1,6 @@
-import { router } from "expo-router";
 import { StyleSheet, View } from "react-native";
 
+import { useDeleteUserAccountMutation } from "@apis/user";
 import { AppText, CustomButton, CustomModal } from "@shared/ui";
 import { colors } from "@theme/token";
 
@@ -13,10 +13,11 @@ export default function DeleteAccountModal({
   isVisible,
   handleCloseModal,
 }: DeleteAccountModalProps) {
-  // TODO: 회원탈퇴 api 연동
+  // TODO: isPendingDeleteUserAccount 이용히여 추후 로딩 처리
+  const { deleteUserAccount } = useDeleteUserAccountMutation();
   const handleDeleteAccount = () => {
     handleCloseModal();
-    router.replace("/delete-account-complete");
+    deleteUserAccount();
   };
 
   return (

--- a/screens/my-page/components/logout-modal/index.tsx
+++ b/screens/my-page/components/logout-modal/index.tsx
@@ -1,6 +1,6 @@
 import { StyleSheet, View } from "react-native";
 
-import { clearAuthAndRedirectToLogin } from "@apis/auth-guard";
+import { useLogout } from "@apis/auth";
 import { AppText, CustomButton, CustomModal } from "@shared/ui";
 import { colors } from "@theme/token";
 
@@ -13,9 +13,10 @@ export default function LogoutModal({
   isVisible,
   handleCloseModal,
 }: LogoutModalProps) {
+  const { logout } = useLogout();
   const handleLogout = () => {
     handleCloseModal();
-    clearAuthAndRedirectToLogin();
+    logout();
   };
 
   return (

--- a/screens/my-page/components/logout-modal/index.tsx
+++ b/screens/my-page/components/logout-modal/index.tsx
@@ -1,6 +1,6 @@
-import { router } from "expo-router";
 import { StyleSheet, View } from "react-native";
 
+import { clearAuthAndRedirectToLogin } from "@apis/auth-guard";
 import { AppText, CustomButton, CustomModal } from "@shared/ui";
 import { colors } from "@theme/token";
 
@@ -13,10 +13,9 @@ export default function LogoutModal({
   isVisible,
   handleCloseModal,
 }: LogoutModalProps) {
-  // TODO: 로그아웃 연동
   const handleLogout = () => {
     handleCloseModal();
-    router.push("/login");
+    clearAuthAndRedirectToLogin();
   };
 
   return (

--- a/screens/my-page/my-page-screen.tsx
+++ b/screens/my-page/my-page-screen.tsx
@@ -2,18 +2,15 @@ import { router } from "expo-router";
 import { useState } from "react";
 import { Pressable, ScrollView, StyleSheet, View } from "react-native";
 
+import { useGetUserInfoQuery } from "@apis/user";
 import { AppText, UserProfileBar } from "@shared/ui";
 import { colors } from "@theme/token";
 
 import { LogoutModal, SettingsListItem } from "./components";
 import { SETTINGS_MY_ACTIVITY, SETTINGS_OTHER } from "./constants";
 
-// TODO: 서버에서 받아오기
-const nickname = "ThipUser01";
-const genre = "문학가";
-const profileColor = colors.character.mint;
-
 export default function MyPageScreen() {
+  const { userInfo } = useGetUserInfoQuery();
   const [isLogoutModalVisible, setLogoutModalVisible] = useState(false);
 
   const handleToEdit = () => {
@@ -35,7 +32,11 @@ export default function MyPageScreen() {
     <ScrollView contentContainerStyle={styles.page}>
       <UserProfileBar
         type="edit-profile"
-        userProfile={{ nickname, genre, profileColor }}
+        userProfile={{
+          nickname: userInfo?.nickname ?? "",
+          genre: userInfo?.aliasName ?? "",
+          profileColor: userInfo?.aliasColor ?? colors.grey[300],
+        }}
         handleToEdit={handleToEdit}
       />
       <View style={styles.section}>

--- a/src/apis/auth/auth.queries.ts
+++ b/src/apis/auth/auth.queries.ts
@@ -43,8 +43,8 @@ export const useLoginMutation = () => {
 
 export const useLogout = () => {
   const queryClient = useQueryClient();
-  const logout = () => {
-    clearAuthAndRedirectToLogin();
+  const logout = async () => {
+    await clearAuthAndRedirectToLogin();
     queryClient.invalidateQueries({
       queryKey: USER_QUERY_KEY.USER_INFO,
     });

--- a/src/apis/auth/auth.queries.ts
+++ b/src/apis/auth/auth.queries.ts
@@ -1,8 +1,10 @@
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { router } from "expo-router";
 import Toast from "react-native-toast-message";
 
+import { clearAuthAndRedirectToLogin } from "../auth-guard";
 import { setAuthToken } from "../token-storage";
+import { USER_QUERY_KEY } from "../user";
 import { loginApi } from "./auth.api";
 import type { LoginRequest, LoginResponse } from "./auth.types";
 
@@ -37,4 +39,16 @@ export const useLoginMutation = () => {
     login,
     isPendingLogin, // TODO: 추후 로딩 애니메이션 보여주기
   };
+};
+
+export const useLogout = () => {
+  const queryClient = useQueryClient();
+  const logout = () => {
+    clearAuthAndRedirectToLogin();
+    queryClient.invalidateQueries({
+      queryKey: USER_QUERY_KEY.USER_INFO,
+    });
+  };
+
+  return { logout };
 };

--- a/src/apis/auth/index.ts
+++ b/src/apis/auth/index.ts
@@ -1,4 +1,4 @@
 export { loginApi } from "./auth.api";
-export { initializeKakao } from "./kakao";
-export { useLoginMutation } from "./auth.queries";
+export { useLoginMutation, useLogout } from "./auth.queries";
 export type { LoginRequest, LoginResponse } from "./auth.types";
+export { initializeKakao } from "./kakao";

--- a/src/apis/user/index.ts
+++ b/src/apis/user/index.ts
@@ -1,5 +1,6 @@
 export {
   checkNicknameApi,
+  deleteUserAccountApi,
   getAliasListApi,
   getUserInfoApi,
   signupApi,
@@ -7,6 +8,7 @@ export {
 
 export {
   useCheckNicknameMutation,
+  useDeleteUserAccountMutation,
   useGetAliasListQuery,
   useGetUserInfoQuery,
   useSignupMutation,

--- a/src/apis/user/index.ts
+++ b/src/apis/user/index.ts
@@ -1,6 +1,7 @@
 export {
   checkNicknameApi,
   deleteUserAccountApi,
+  editUserProfileApi,
   getAliasListApi,
   getUserInfoApi,
   signupApi,
@@ -9,6 +10,7 @@ export {
 export {
   useCheckNicknameMutation,
   useDeleteUserAccountMutation,
+  useEditUserProfileMutation,
   useGetAliasListQuery,
   useGetUserInfoQuery,
   useSignupMutation,
@@ -18,6 +20,7 @@ export type {
   AliasChoiceType,
   CheckNicknameRequest,
   CheckNicknameResponse,
+  EditUserProfileRequest,
   GetAliasListResponse,
   GetUserInfoResponse,
   SignupRequest,

--- a/src/apis/user/user.api.ts
+++ b/src/apis/user/user.api.ts
@@ -41,3 +41,7 @@ export const getUserInfoApi = async () => {
 
   return response.data;
 };
+
+export const deleteUserAccountApi = async () => {
+  await apiClient.delete<string>(USER_URL.DEFAULT);
+};

--- a/src/apis/user/user.api.ts
+++ b/src/apis/user/user.api.ts
@@ -4,6 +4,7 @@ import { USER_URL } from "@apis/endpoint";
 import type {
   CheckNicknameRequest,
   CheckNicknameResponse,
+  EditUserProfileRequest,
   GetAliasListResponse,
   GetUserInfoResponse,
   SignupRequest,
@@ -44,4 +45,8 @@ export const getUserInfoApi = async () => {
 
 export const deleteUserAccountApi = async () => {
   await apiClient.delete<string>(USER_URL.DEFAULT);
+};
+
+export const editUserProfileApi = async (body: EditUserProfileRequest) => {
+  await apiClient.patch<string, EditUserProfileRequest>(USER_URL.DEFAULT, body);
 };

--- a/src/apis/user/user.queries.ts
+++ b/src/apis/user/user.queries.ts
@@ -149,6 +149,7 @@ export const useEditUserProfileMutation = () => {
       queryClient.invalidateQueries({
         queryKey: USER_QUERY_KEY.USER_INFO,
       });
+      router.back();
     },
     onError: (error) => {
       Toast.show({
@@ -167,16 +168,24 @@ export const useEditUserProfileMutation = () => {
 };
 
 export const useDeleteUserAccountMutation = () => {
+  const queryClient = useQueryClient();
+
   const { mutate: deleteUserAccount, isPending: isPendingDeleteUserAccount } =
     useMutation<void, Error>({
       mutationFn: deleteUserAccountApi,
       onSuccess: async () => {
         try {
           await deleteAuthToken();
+          queryClient.invalidateQueries({
+            queryKey: USER_QUERY_KEY.USER_INFO,
+          });
+          router.replace("/delete-account-complete");
         } catch (error) {
           console.error("[auth] token delete failed", error);
-        } finally {
-          router.replace("/delete-account-complete");
+          Toast.show({
+            type: "error",
+            text1: "토큰 삭제에 실패했습니다. 앱 종료 후 다시 시도해주세요.",
+          });
         }
       },
       onError: (error) => {

--- a/src/apis/user/user.queries.ts
+++ b/src/apis/user/user.queries.ts
@@ -1,4 +1,4 @@
-import { useMutation, useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { router } from "expo-router";
 import Toast from "react-native-toast-message";
 
@@ -6,6 +6,7 @@ import { deleteAuthToken, setAuthToken } from "../token-storage";
 import {
   checkNicknameApi,
   deleteUserAccountApi,
+  editUserProfileApi,
   getAliasListApi,
   getUserInfoApi,
   signupApi,
@@ -14,6 +15,7 @@ import { USER_QUERY_KEY } from "./user.query-key";
 import type {
   CheckNicknameRequest,
   CheckNicknameResponse,
+  EditUserProfileRequest,
   GetAliasListResponse,
   GetUserInfoResponse,
   SignupRequest,
@@ -130,6 +132,37 @@ export const useGetUserInfoQuery = () => {
     isPendingUserInfo,
     isErrorUserInfo,
     userInfoError,
+  };
+};
+
+export const useEditUserProfileMutation = () => {
+  const queryClient = useQueryClient();
+
+  const {
+    mutate: editUserProfile,
+    isPending: isPendingEditUserProfile,
+    isError: isErrorEditUserProfile,
+    error: editUserProfileError,
+  } = useMutation<void, Error, EditUserProfileRequest>({
+    mutationFn: editUserProfileApi,
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: USER_QUERY_KEY.USER_INFO,
+      });
+    },
+    onError: (error) => {
+      Toast.show({
+        type: "error",
+        text1: `${error.message}`,
+      });
+    },
+  });
+
+  return {
+    editUserProfile,
+    isPendingEditUserProfile,
+    isErrorEditUserProfile,
+    editUserProfileError,
   };
 };
 

--- a/src/apis/user/user.queries.ts
+++ b/src/apis/user/user.queries.ts
@@ -2,9 +2,10 @@ import { useMutation, useQuery } from "@tanstack/react-query";
 import { router } from "expo-router";
 import Toast from "react-native-toast-message";
 
-import { setAuthToken } from "../token-storage";
+import { deleteAuthToken, setAuthToken } from "../token-storage";
 import {
   checkNicknameApi,
+  deleteUserAccountApi,
   getAliasListApi,
   getUserInfoApi,
   signupApi,
@@ -94,7 +95,6 @@ export const useSignupMutation = () => {
         });
       }
     },
-    // TODO: 예외처리 UI 추가
     onError: (error) => {
       console.error("[useSignupMutation] signup failed", error);
       Toast.show({
@@ -130,5 +130,32 @@ export const useGetUserInfoQuery = () => {
     isPendingUserInfo,
     isErrorUserInfo,
     userInfoError,
+  };
+};
+
+export const useDeleteUserAccountMutation = () => {
+  const { mutate: deleteUserAccount, isPending: isPendingDeleteUserAccount } =
+    useMutation<void, Error>({
+      mutationFn: deleteUserAccountApi,
+      onSuccess: async () => {
+        try {
+          await deleteAuthToken();
+        } catch (error) {
+          console.error("[auth] token delete failed", error);
+        } finally {
+          router.replace("/delete-account-complete");
+        }
+      },
+      onError: (error) => {
+        Toast.show({
+          type: "error",
+          text1: `회원탈퇴에 실패했습니다. ${error.message}`,
+        });
+      },
+    });
+
+  return {
+    deleteUserAccount,
+    isPendingDeleteUserAccount,
   };
 };

--- a/src/apis/user/user.types.ts
+++ b/src/apis/user/user.types.ts
@@ -33,3 +33,8 @@ export interface GetUserInfoResponse {
   aliasName: string;
   aliasColor: string;
 }
+
+export interface EditUserProfileRequest {
+  aliasName?: string;
+  nickname?: string;
+}


### PR DESCRIPTION
## 📌 Related Issues

- close #93 

## 📄 Tasks

- 로그아웃은 api 가 따로 없어서 토큰을 삭제하고 로그인 화면으로 보내도록 함
- 회원탈퇴 api 연동
- 프로필 수정 api 연동

## 실기기 테스트 필요!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * 프로필 편집이 실제 사용자 정보 기반으로 동기화되고, 닉네임/장르 변경을 API로 저장합니다.
  * 마이페이지가 더미 값이 아닌 실제 사용자 정보(닉네임/칭호/프로필 컬러)를 표시합니다.
  * 회원탈퇴 완료 화면에서 3초 후 자동으로 로그인 화면으로 이동합니다.
  * 로그아웃 모달이 인증 API 호출로 로그아웃을 수행합니다.
* **Bug Fixes**
  * 탈퇴/프로필 수정 중에는 버튼 입력이 비활성화되어 중복 실행을 방지합니다.
* **Chores**
  * 테스트 실행 스크립트를 추가해 `node --test`로 동작하도록 변경했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->