### PR TITLE
[Feature/#96] 피드 작성 api 연동

### DIFF
--- a/screens/create-group/create-group-screen.tsx
+++ b/screens/create-group/create-group-screen.tsx
@@ -14,7 +14,7 @@ import type { GroupCategoryType } from "@shared/types";
 import {
   BookSearchBottomSheet,
   BookSelectSection,
-  type FeedBookItemType,
+  type BottomSheetBookItemType,
   VisibilitySection,
 } from "@shared/ui";
 import { getKoreaDate, parseStringToDate } from "@shared/utils";
@@ -37,7 +37,7 @@ export default function CreateGroupScreen() {
   const { selectedBookInfo, clearSelectedBookInfo } = useSelectedBookStore();
 
   const [isBottomSheetVisible, setIsBottomSheetVisible] = useState(false);
-  const [groupBook, setGroupBook] = useState<FeedBookItemType | null>(
+  const [groupBook, setGroupBook] = useState<BottomSheetBookItemType | null>(
     selectedBookInfo ?? null,
   );
   const [selectedCategory, setSelectedCategory] =

--- a/screens/feed-write/components/feed-tag-section/index.tsx
+++ b/screens/feed-write/components/feed-tag-section/index.tsx
@@ -1,11 +1,12 @@
 import { useMemo, useState } from "react";
 import { FlatList, Pressable, StyleSheet, View } from "react-native";
 
+import { useGetFeedTagListQuery } from "@apis/feed";
 import { IcX } from "@images/icons";
 import { AppText, SelectChip, TagButton } from "@shared/ui";
 import { colors } from "@theme/token";
 
-import { FEED_TAG_LIST, FEED_TAG_MAX } from "../../constants";
+import { FEED_TAG_MAX } from "../../constants";
 
 interface FeedTagSectionProps {
   selectedTagList: string[];
@@ -18,6 +19,8 @@ export default function FeedTagSection({
   handlePressTag,
   handleDeleteTag,
 }: FeedTagSectionProps) {
+  // TODO: isPendingFeedTagList에 대한 스켈레톤 처리
+  const { categoryList } = useGetFeedTagListQuery();
   const [selectedCategory, setSelectedCategory] = useState<string>();
 
   const handleSelectCategory = (label: string) => {
@@ -26,10 +29,10 @@ export default function FeedTagSection({
 
   const tagList = useMemo(() => {
     return (
-      FEED_TAG_LIST.find((item) => item.label === selectedCategory)?.tagList ??
-      []
+      categoryList.find((item) => item.category === selectedCategory)
+        ?.tagList ?? []
     );
-  }, [selectedCategory]);
+  }, [categoryList, selectedCategory]);
 
   const isMax = selectedTagList.length === FEED_TAG_MAX;
 
@@ -61,13 +64,13 @@ export default function FeedTagSection({
         contentContainerStyle={styles.horizontalList}
         horizontal
         showsHorizontalScrollIndicator={false}
-        data={FEED_TAG_LIST}
-        keyExtractor={(item) => String(item.type)}
+        data={categoryList}
+        keyExtractor={(item) => item.category}
         renderItem={({ item }) => (
           <SelectChip
-            label={item.label}
-            isSelected={item.label === selectedCategory}
-            handleSelect={() => handleSelectCategory(item.label)}
+            label={item.category}
+            isSelected={item.category === selectedCategory}
+            handleSelect={() => handleSelectCategory(item.category)}
             type="category"
           />
         )}

--- a/screens/feed-write/feed-write-screen.tsx
+++ b/screens/feed-write/feed-write-screen.tsx
@@ -9,6 +9,7 @@ import {
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
+import { useWriteFeedMutation } from "@apis/feed";
 import {
   BookSearchBottomSheet,
   BookSelectSection,
@@ -32,6 +33,7 @@ export default function FeedWriteScreen() {
   const navigation = useNavigation();
   const { pinInfo, clearPinInfo } = useRecordBookPinStore();
   const { selectedBookInfo, clearSelectedBookInfo } = useSelectedBookStore();
+  const { writeFeed, isPendingWriteFeed } = useWriteFeedMutation();
 
   const [isBottomSheetVisible, setIsBottomSheetVisible] = useState(false);
   const [feedBook, setFeedBook] = useState<FeedBookItemType | null>(
@@ -81,21 +83,35 @@ export default function FeedWriteScreen() {
     setSelectedTagList((prev) => prev.filter((item) => item !== tag));
   };
 
-  // TODO: 작성 정보 서버에 보내도록
   const handleConfirmFeedWrite = () => {
-    alert(
-      `책 : ${feedBook?.bookTitle}\n글 : ${contentBody}\n사진 : ${imageUrls}\n공개 설정 : ${isPublic}\n태그 : ${selectedTagList}`,
+    if (!feedBook) {
+      return;
+    }
+
+    writeFeed(
+      {
+        isbn: feedBook.isbn,
+        contentBody: contentBody.trim(),
+        isPublic,
+        tagList: selectedTagList,
+        imageUris: imageUrls,
+      },
+      {
+        onSuccess: () => {
+          clearPinInfo();
+          clearSelectedBookInfo();
+          router.back();
+        },
+      },
     );
-    clearPinInfo();
-    clearSelectedBookInfo();
-    router.back();
   };
 
   const Separator = () => {
     return <View style={styles.separator} />;
   };
 
-  const confirmDisable = !feedBook || contentBody.trim() === "";
+  const confirmDisable =
+    !feedBook || contentBody.trim() === "" || isPendingWriteFeed;
 
   return (
     <View style={styles.page}>

--- a/screens/feed-write/feed-write-screen.tsx
+++ b/screens/feed-write/feed-write-screen.tsx
@@ -13,7 +13,7 @@ import { useWriteFeedMutation } from "@apis/feed";
 import {
   BookSearchBottomSheet,
   BookSelectSection,
-  type FeedBookItemType,
+  type BottomSheetBookItemType,
   VisibilitySection,
 } from "@shared/ui";
 import { useRecordBookPinStore } from "@stores/record-book";
@@ -36,7 +36,7 @@ export default function FeedWriteScreen() {
   const { writeFeed, isPendingWriteFeed } = useWriteFeedMutation();
 
   const [isBottomSheetVisible, setIsBottomSheetVisible] = useState(false);
-  const [feedBook, setFeedBook] = useState<FeedBookItemType | null>(
+  const [feedBook, setFeedBook] = useState<BottomSheetBookItemType | null>(
     pinInfo?.bookInfo ?? selectedBookInfo ?? null,
   );
   const [contentBody, setContentBody] = useState(pinInfo?.content ?? "");

--- a/screens/search/components/search-result/index.tsx
+++ b/screens/search/components/search-result/index.tsx
@@ -26,32 +26,20 @@ export default function SearchResult({
     fetchNextPage,
     hasNextPage,
     isPendingSearchBook,
-    isFetchingSearchBook,
     isFetchingNextPage,
   } = useSearchBookQuery(searchText, 1, hasSearched);
 
   useEffect(() => {
     const normalizedSearchText = searchText.trim();
 
-    if (
-      !hasSearched ||
-      normalizedSearchText === "" ||
-      isPendingSearchBook ||
-      isFetchingSearchBook
-    ) {
+    if (!hasSearched || normalizedSearchText === "" || isPendingSearchBook) {
       return;
     }
 
     void queryClient.invalidateQueries({
       queryKey: RECENT_SEARCH_QUERY_KEY.LIST("BOOK"),
     });
-  }, [
-    hasSearched,
-    isFetchingSearchBook,
-    isPendingSearchBook,
-    queryClient,
-    searchText,
-  ]);
+  }, [hasSearched, isPendingSearchBook, queryClient, searchText]);
 
   const handleToBookRequestPage = useCallback(() => {
     router.push("/book-request");

--- a/src/apis/book/book.api.ts
+++ b/src/apis/book/book.api.ts
@@ -1,14 +1,16 @@
 import { apiClient } from "../api-client";
 import { BOOK_URL } from "../endpoint";
-import {
+import type {
+  BookSelectableListType,
+  ChangeBookSaveStatusRequest,
+  ChangeBookSaveStatusResponse,
+  GetBookDetailResponse,
   GetBookRecruitingRoomsResponse,
+  GetBookSelectableListResponse,
+  GetMostSearchedBookResponse,
   GetSavedBookResponse,
-  type ChangeBookSaveStatusRequest,
-  type ChangeBookSaveStatusResponse,
-  type GetBookDetailResponse,
-  type GetMostSearchedBookResponse,
-  type GetSearchBookRequest,
-  type GetSearchBookResponse,
+  GetSearchBookRequest,
+  GetSearchBookResponse,
 } from "./book.types";
 
 export const getSearchBookApi = async (params: GetSearchBookRequest) => {
@@ -68,6 +70,20 @@ export const getBookRecruitingRoomsApi = async (
     BOOK_URL.RECRUITING(isbn),
     {
       params: cursor == null ? undefined : { cursor },
+    },
+  );
+
+  return response.data;
+};
+
+export const getBookSelectableListApi = async (
+  type: BookSelectableListType,
+  cursor?: string | null,
+) => {
+  const response = await apiClient.get<GetBookSelectableListResponse>(
+    BOOK_URL.SELECTABLE_LIST,
+    {
+      params: cursor == null ? { type } : { type, cursor },
     },
   );
 

--- a/src/apis/book/book.queries.ts
+++ b/src/apis/book/book.queries.ts
@@ -13,19 +13,22 @@ import {
   changeBookSaveStatusApi,
   getBookDetailApi,
   getBookRecruitingRoomsApi,
+  getBookSelectableListApi,
   getMostSearchedBookApi,
   getSavedBookApi,
   getSearchBookApi,
 } from "./book.api";
 import { BOOK_QUERY_KEY } from "./book.query-key";
-import {
+import type {
+  BookSelectableListType,
   ChangeBookSaveStatusRequest,
   ChangeBookSaveStatusResponse,
   GetBookDetailResponse,
   GetBookRecruitingRoomsResponse,
+  GetBookSelectableListResponse,
   GetMostSearchedBookResponse,
   GetSavedBookResponse,
-  type GetSearchBookResponse,
+  GetSearchBookResponse,
 } from "./book.types";
 
 const BOOK_QUERY_CACHE_TIME = {
@@ -41,6 +44,7 @@ const MOST_SEARCHED_BOOK_QUERY_CACHE_TIME = {
 type BookSearchPage = number;
 type SavedBookCursor = string | null;
 type BookRecruitingRoomCursor = string | null;
+type BookSelectableListCursor = string | null;
 
 export const useSearchBookQuery = (
   keyword: string,
@@ -103,6 +107,7 @@ export const useSearchBookQuery = (
     isPendingSearchBook,
     isFetchingSearchBook,
     isFetchingNextPage,
+    isErrorSearchBook,
   };
 };
 
@@ -290,5 +295,39 @@ export const useBookRecruitingRoomsQuery = (isbn: string) => {
     isErrorBookRecruitingRooms,
     refetchBookRecruitingRooms,
     isRefetchingBookRecruitingRooms,
+  };
+};
+
+export const useBookSelectableListQuery = (type: BookSelectableListType) => {
+  const {
+    data,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    isPending: isPendingBookSelectableList,
+    isError: isErrorBookSelectableList,
+  } = useInfiniteQuery<
+    GetBookSelectableListResponse,
+    Error,
+    InfiniteData<GetBookSelectableListResponse, BookSelectableListCursor>,
+    ReturnType<typeof BOOK_QUERY_KEY.SELECTABLE_LIST>,
+    BookSelectableListCursor
+  >({
+    queryKey: BOOK_QUERY_KEY.SELECTABLE_LIST(type),
+    queryFn: ({ pageParam }) => getBookSelectableListApi(type, pageParam),
+    initialPageParam: null,
+    getNextPageParam: (lastPage) =>
+      lastPage.isLast ? undefined : lastPage.nextCursor || undefined,
+    staleTime: BOOK_QUERY_CACHE_TIME.STALE,
+    gcTime: BOOK_QUERY_CACHE_TIME.GC,
+  });
+
+  return {
+    bookSelectableList: data?.pages.flatMap((page) => page.bookList) ?? [],
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    isPendingBookSelectableList,
+    isErrorBookSelectableList,
   };
 };

--- a/src/apis/book/book.queries.ts
+++ b/src/apis/book/book.queries.ts
@@ -58,7 +58,6 @@ export const useSearchBookQuery = (
     fetchNextPage,
     hasNextPage,
     isPending: isPendingSearchBook,
-    isFetching: isFetchingSearchBook,
     isFetchingNextPage,
     isError: isErrorSearchBook,
     error: searchBookError,
@@ -105,7 +104,6 @@ export const useSearchBookQuery = (
     fetchNextPage,
     hasNextPage,
     isPendingSearchBook,
-    isFetchingSearchBook,
     isFetchingNextPage,
     isErrorSearchBook,
   };

--- a/src/apis/book/book.query-key.ts
+++ b/src/apis/book/book.query-key.ts
@@ -1,3 +1,5 @@
+import { type BookSelectableListType } from "./book.types";
+
 export const BOOK_QUERY_KEY = {
   ALL: ["books"],
   SEARCH: (keyword: string, page: number, isFinalized: boolean) => [
@@ -11,4 +13,5 @@ export const BOOK_QUERY_KEY = {
   MOST: ["books", "most-searched"],
   SAVED: ["books", "saved"],
   RECRUITING: (isbn?: string) => ["books", "recruiting", isbn],
+  SELECTABLE_LIST: (type: BookSelectableListType) => ["books", "saved", type],
 } as const;

--- a/src/apis/book/book.types.ts
+++ b/src/apis/book/book.types.ts
@@ -87,3 +87,20 @@ export interface GetBookRecruitingRoomsResponse {
   nextCursor: string;
   isLast: boolean;
 }
+
+export type BookSelectableListType = "SAVED" | "JOINING";
+
+export interface SelectableBookType {
+  bookId: number;
+  bookTitle: string;
+  authorName: string;
+  publisher: string;
+  bookImageUrl: string;
+  isbn: string;
+}
+
+export interface GetBookSelectableListResponse {
+  bookList: SelectableBookType[];
+  nextCursor: string;
+  isLast: boolean;
+}

--- a/src/apis/book/index.ts
+++ b/src/apis/book/index.ts
@@ -2,6 +2,7 @@ export {
   changeBookSaveStatusApi,
   getBookDetailApi,
   getBookRecruitingRoomsApi,
+  getBookSelectableListApi,
   getMostSearchedBookApi,
   getSavedBookApi,
   getSearchBookApi,
@@ -10,6 +11,7 @@ export {
 export {
   useBookDetailQuery,
   useBookRecruitingRoomsQuery,
+  useBookSelectableListQuery,
   useChangeBookSaveStatusMutation,
   useMostSearchedBookQuery,
   useSavedBookQuery,
@@ -17,11 +19,13 @@ export {
 } from "./book.queries";
 
 export type {
+  BookSelectableListType,
   BookType,
   ChangeBookSaveStatusRequest,
   ChangeBookSaveStatusResponse,
   GetBookDetailResponse,
   GetBookRecruitingRoomsResponse,
+  GetBookSelectableListResponse,
   GetMostSearchedBookResponse,
   GetSavedBookResponse,
   GetSearchBookRequest,
@@ -29,6 +33,7 @@ export type {
   MostSearchedBook,
   RecruitingRoomType,
   SavedBookType,
+  SelectableBookType,
 } from "./book.types";
 
 export { BOOK_QUERY_KEY } from "./book.query-key";

--- a/src/apis/endpoint.ts
+++ b/src/apis/endpoint.ts
@@ -55,6 +55,7 @@ export const BOOK_URL = {
   SAVE_STATUS: (isbn: string) => `/books/${encodeURIComponent(isbn)}/saved`,
   RECRUITING: (isbn: string) =>
     `/books/${encodeURIComponent(isbn)}/recruiting-rooms`,
+  SELECTABLE_LIST: "/books/selectable-list",
 } as const;
 
 export const ROOM_URL = {

--- a/src/apis/endpoint.ts
+++ b/src/apis/endpoint.ts
@@ -22,7 +22,7 @@ export const FEED_URL = {
   DETAIL: (feedId: number | string) =>
     `/feeds/${encodeURIComponent(String(feedId))}`,
   TAG_LIST: "/feeds/write-info",
-  RELATED_BOOK: (isbn: string) =>
+  RELATED_BOOKS: (isbn: string) =>
     `/feeds/related-books/${encodeURIComponent(isbn)}`,
   USER_PROFILE: (userId: number) =>
     `/feeds/users/${encodeURIComponent(userId)}`,
@@ -33,6 +33,7 @@ export const FEED_URL = {
   SAVED: "/feeds/saved",
   SAVE_STATUS: (feedId: number) => `/feeds/${encodeURIComponent(feedId)}/saved`,
   LIKE_STATUS: (feedId: number) => `/feeds/${encodeURIComponent(feedId)}/likes`,
+  PRESIGNED_URL: "/feeds/images/presigned-url",
 } as const;
 
 export const COMMENT_URL = {

--- a/src/apis/feed/feed.api.ts
+++ b/src/apis/feed/feed.api.ts
@@ -12,7 +12,15 @@ import type {
   GetFeedUserProfileRequest,
   GetFeedUserProfileResponse,
   GetUserProfileTopInfoResponse,
+  IssuePresignedUrlRequest,
+  IssuePresignedUrlResponse,
+  WriteFeedRequest,
+  WriteFeedResponse,
 } from "./feed.types";
+import {
+  createPresignedImageRequests,
+  uploadImageToPresignedUrl,
+} from "./feed.utils";
 
 export const getAllFeedListApi = async (cursor?: string | null) => {
   const response = await apiClient.get<GetFeedListResponse>(FEED_URL.DEFAULT, {
@@ -44,7 +52,7 @@ export const getFeedRelatedBookApi = async ({
   cursor,
 }: GetFeedRelatedBookRequest) => {
   const response = await apiClient.get<GetFeedRelatedBookResponse>(
-    FEED_URL.RELATED_BOOK(isbn),
+    FEED_URL.RELATED_BOOKS(isbn),
     {
       params: cursor == null ? { sort } : { sort, cursor },
     },
@@ -125,6 +133,67 @@ export const changeFeedLikeStatusApi = async ({
     {
       type,
     },
+  );
+
+  return response.data;
+};
+
+export const issuePresignedUrlApi = async (
+  images: IssuePresignedUrlRequest,
+) => {
+  const response = await apiClient.post<IssuePresignedUrlResponse>(
+    FEED_URL.PRESIGNED_URL,
+    images,
+  );
+
+  return response.data;
+};
+
+const getFeedImageBlob = async (uri: string) => {
+  const response = await fetch(uri);
+
+  if (!response.ok) {
+    throw new Error(`Feed image load failed. status: ${response.status}`);
+  }
+
+  return response.blob();
+};
+
+export const uploadFeedImagesApi = async (imageUris: string[]) => {
+  if (imageUris.length === 0) {
+    return [];
+  }
+
+  const images = await Promise.all(
+    imageUris.map(async (uri) => ({
+      uri,
+      blob: await getFeedImageBlob(uri),
+    })),
+  );
+  const { presignedUrls } = await issuePresignedUrlApi(
+    createPresignedImageRequests(images),
+  );
+
+  if (presignedUrls.length !== images.length) {
+    throw new Error("Issued presigned URL count does not match image count.");
+  }
+
+  await Promise.all(
+    presignedUrls.map(({ presignedUrl }, index) =>
+      uploadImageToPresignedUrl({
+        presignedUrl,
+        blob: images[index].blob,
+      }),
+    ),
+  );
+
+  return presignedUrls.map(({ fileUrl }) => fileUrl);
+};
+
+export const writeFeedApi = async (body: WriteFeedRequest) => {
+  const response = await apiClient.post<WriteFeedResponse>(
+    FEED_URL.DEFAULT,
+    body,
   );
 
   return response.data;

--- a/src/apis/feed/feed.queries.ts
+++ b/src/apis/feed/feed.queries.ts
@@ -436,18 +436,10 @@ export const useChangeFeedSaveStatusMutation = () => {
   } = useMutation<ChangeFeedSaveStatusResponse, Error, ChangeFeedStatusRequest>(
     {
       mutationFn: changeFeedSaveStatusApi,
-      onSuccess: async (_, variables) => {
-        await Promise.all([
-          queryClient.invalidateQueries({
-            queryKey: FEED_QUERY_KEY.ALL,
-          }),
-          queryClient.invalidateQueries({
-            queryKey: FEED_QUERY_KEY.DETAIL(variables.feedId),
-          }),
-          queryClient.invalidateQueries({
-            queryKey: FEED_QUERY_KEY.SAVED,
-          }),
-        ]);
+      onSuccess: async () => {
+        queryClient.invalidateQueries({
+          queryKey: FEED_QUERY_KEY.ALL,
+        });
       },
       onError: (error) => {
         Toast.show({
@@ -469,18 +461,10 @@ export const useChangeFeedLikeStatusMutation = () => {
   } = useMutation<ChangeFeedLikeStatusResponse, Error, ChangeFeedStatusRequest>(
     {
       mutationFn: changeFeedLikeStatusApi,
-      onSuccess: async (_, variables) => {
-        await Promise.all([
-          queryClient.invalidateQueries({
-            queryKey: FEED_QUERY_KEY.ALL,
-          }),
-          queryClient.invalidateQueries({
-            queryKey: FEED_QUERY_KEY.DETAIL(variables.feedId),
-          }),
-          queryClient.invalidateQueries({
-            queryKey: FEED_QUERY_KEY.SAVED,
-          }),
-        ]);
+      onSuccess: () => {
+        queryClient.invalidateQueries({
+          queryKey: FEED_QUERY_KEY.ALL,
+        });
       },
       onError: (error) => {
         Toast.show({
@@ -509,18 +493,10 @@ export const useWriteFeedMutation = () => {
         imageUrls,
       });
     },
-    onSuccess: async (_, variables) => {
-      await Promise.all([
-        queryClient.invalidateQueries({
-          queryKey: FEED_QUERY_KEY.ALL,
-        }),
-        queryClient.invalidateQueries({
-          queryKey: FEED_QUERY_KEY.MY_PROFILE,
-        }),
-        queryClient.invalidateQueries({
-          queryKey: FEED_QUERY_KEY.RELATED_BOOKS(variables.isbn),
-        }),
-      ]);
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: FEED_QUERY_KEY.ALL,
+      });
     },
     onError: (error) => {
       Toast.show({

--- a/src/apis/feed/feed.queries.ts
+++ b/src/apis/feed/feed.queries.ts
@@ -146,10 +146,8 @@ export const useGetFeedTagListQuery = () => {
   const {
     data: feedTagList,
     isPending: isPendingFeedTagList,
-    isError: isErrorFeedTagList,
-    error: feedTagListError,
-    refetch: refetchFeedTagList,
-    isRefetching: isRefetchingFeedTagList,
+    isError,
+    error,
   } = useQuery<GetFeedTagListResponse, Error>({
     queryKey: FEED_QUERY_KEY.TAG_LIST,
     queryFn: getFeedTagListApi,
@@ -157,13 +155,22 @@ export const useGetFeedTagListQuery = () => {
     gcTime: FEED_TAG_QUERY_CACHE_TIME.GC,
   });
 
+  useEffect(() => {
+    if (!isError || !error) return;
+
+    Toast.show({
+      type: "error",
+      text1: error.message,
+    });
+
+    if (!feedTagList && router.canGoBack()) {
+      router.back();
+    }
+  }, [isError, error, feedTagList]);
+
   return {
     categoryList: feedTagList?.categoryList ?? [],
     isPendingFeedTagList,
-    isErrorFeedTagList,
-    feedTagListError,
-    refetchFeedTagList,
-    isRefetchingFeedTagList,
   };
 };
 

--- a/src/apis/feed/feed.queries.ts
+++ b/src/apis/feed/feed.queries.ts
@@ -21,6 +21,8 @@ import {
   getMyProfileTopInfoApi,
   getSavedFeedApi,
   getUserProfileTopInfoApi,
+  uploadFeedImagesApi,
+  writeFeedApi,
 } from "./feed.api";
 import { FEED_QUERY_KEY } from "./feed.query-key";
 import type {
@@ -34,6 +36,8 @@ import type {
   GetFeedTagListResponse,
   GetFeedUserProfileResponse,
   GetUserProfileTopInfoResponse,
+  WriteFeedMutationRequest,
+  WriteFeedResponse,
 } from "./feed.types";
 
 type FeedCursor = string | null;
@@ -183,10 +187,10 @@ export const useGetFeedRelatedBookQuery = (
     GetFeedRelatedBookResponse,
     Error,
     InfiniteData<GetFeedRelatedBookResponse, FeedCursor>,
-    ReturnType<typeof FEED_QUERY_KEY.RELATED_BOOK>,
+    ReturnType<typeof FEED_QUERY_KEY.RELATED_BOOKS>,
     FeedCursor
   >({
-    queryKey: FEED_QUERY_KEY.RELATED_BOOK(normalizedIsbn, sort),
+    queryKey: FEED_QUERY_KEY.RELATED_BOOKS(normalizedIsbn, sort),
     queryFn: ({ pageParam }) => {
       if (!hasIsbn(normalizedIsbn)) {
         throw new Error("isbn is required.");
@@ -488,4 +492,43 @@ export const useChangeFeedLikeStatusMutation = () => {
   );
 
   return { changeFeedLikeStatus, isPendingChangeFeedLikeStatus };
+};
+
+export const useWriteFeedMutation = () => {
+  const queryClient = useQueryClient();
+  const { mutate: writeFeed, isPending: isPendingWriteFeed } = useMutation<
+    WriteFeedResponse,
+    Error,
+    WriteFeedMutationRequest
+  >({
+    mutationFn: async ({ imageUris, ...feed }) => {
+      const imageUrls = await uploadFeedImagesApi(imageUris);
+
+      return writeFeedApi({
+        ...feed,
+        imageUrls,
+      });
+    },
+    onSuccess: async (_, variables) => {
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: FEED_QUERY_KEY.ALL,
+        }),
+        queryClient.invalidateQueries({
+          queryKey: FEED_QUERY_KEY.MY_PROFILE,
+        }),
+        queryClient.invalidateQueries({
+          queryKey: FEED_QUERY_KEY.RELATED_BOOKS(variables.isbn),
+        }),
+      ]);
+    },
+    onError: (error) => {
+      Toast.show({
+        type: "error",
+        text1: `${error.message}`,
+      });
+    },
+  });
+
+  return { writeFeed, isPendingWriteFeed };
 };

--- a/src/apis/feed/feed.query-key.ts
+++ b/src/apis/feed/feed.query-key.ts
@@ -1,7 +1,7 @@
 import type { FeedRelatedBookSort } from "./feed.types";
 
 export const FEED_QUERY_KEY = {
-  ALL: ["feeds", "all"],
+  ALL: ["feeds"],
   DETAIL: (feedId?: number | string) => [
     "feeds",
     "detail",

--- a/src/apis/feed/feed.query-key.ts
+++ b/src/apis/feed/feed.query-key.ts
@@ -8,9 +8,9 @@ export const FEED_QUERY_KEY = {
     feedId == null || feedId === "" ? undefined : String(feedId),
   ],
   TAG_LIST: ["feeds", "tag-list"],
-  RELATED_BOOK: (isbn?: string, sort: FeedRelatedBookSort = "like") => [
+  RELATED_BOOKS: (isbn?: string, sort: FeedRelatedBookSort = "like") => [
     "feeds",
-    "related-book",
+    "related-books",
     isbn,
     sort,
   ],

--- a/src/apis/feed/feed.types.ts
+++ b/src/apis/feed/feed.types.ts
@@ -106,3 +106,32 @@ export interface ChangeFeedLikeStatusResponse {
   feedId: number;
   isLiked: boolean;
 }
+
+export type IssuePresignedUrlRequest = {
+  extension: string;
+  size: number;
+}[];
+
+export interface IssuePresignedUrlResponse {
+  presignedUrls: {
+    presignedUrl: string;
+    fileUrl: string;
+  }[];
+}
+
+export interface WriteFeedRequest {
+  isbn: string;
+  contentBody: string;
+  isPublic: boolean;
+  tagList: string[];
+  imageUrls: string[];
+}
+
+export interface WriteFeedMutationRequest
+  extends Omit<WriteFeedRequest, "imageUrls"> {
+  imageUris: string[];
+}
+
+export interface WriteFeedResponse {
+  feedId: number;
+}

--- a/src/apis/feed/feed.utils.ts
+++ b/src/apis/feed/feed.utils.ts
@@ -1,0 +1,90 @@
+import type { IssuePresignedUrlRequest } from "./feed.types";
+
+const IMAGE_EXTENSION_BY_MIME_TYPE: Record<string, string> = {
+  "image/heic": "heic",
+  "image/heif": "heif",
+  "image/jpeg": "jpg",
+  "image/jpg": "jpg",
+  "image/png": "png",
+  "image/webp": "webp",
+};
+
+const normalizeImageExtension = (extension: string) => {
+  const normalizedExtension = extension.toLowerCase();
+
+  return normalizedExtension === "jpeg" ? "jpg" : normalizedExtension;
+};
+
+const getImageExtensionFromUri = (uri: string) => {
+  const uriWithoutQuery = uri.split(/[?#]/)[0];
+  const fileName = uriWithoutQuery.slice(uriWithoutQuery.lastIndexOf("/") + 1);
+  const extensionIndex = fileName.lastIndexOf(".");
+
+  if (extensionIndex === -1) {
+    return "";
+  }
+
+  return normalizeImageExtension(fileName.slice(extensionIndex + 1));
+};
+
+const getImageExtension = (uri: string, blob: Blob) => {
+  const extensionFromUri = getImageExtensionFromUri(uri);
+
+  if (extensionFromUri) {
+    return extensionFromUri;
+  }
+
+  return IMAGE_EXTENSION_BY_MIME_TYPE[blob.type.toLowerCase()] ?? "";
+};
+
+interface FeedImageBlob {
+  uri: string;
+  blob: Blob;
+}
+
+type PresignedImageFetch = (
+  url: string,
+  init: {
+    method: "PUT";
+    headers: { "Content-Type": string };
+    body: Blob;
+  },
+) => Promise<Pick<Response, "ok" | "status">>;
+
+interface PresignedImageUpload {
+  presignedUrl: string;
+  blob: Blob;
+}
+
+export const createPresignedImageRequests = (
+  images: FeedImageBlob[],
+): IssuePresignedUrlRequest =>
+  images.map(({ uri, blob }) => {
+    const extension = getImageExtension(uri, blob);
+
+    if (!extension) {
+      throw new Error("Feed image extension is required.");
+    }
+
+    return {
+      extension,
+      size: blob.size,
+    };
+  });
+
+export const uploadImageToPresignedUrl = async (
+  { presignedUrl, blob }: PresignedImageUpload,
+  fetcher: PresignedImageFetch = (url, init) => fetch(url, init),
+) => {
+  const response = await fetcher(presignedUrl, {
+    method: "PUT",
+    headers: {
+      "Content-Type": blob.type || "application/octet-stream",
+    },
+    body: blob,
+  });
+
+  if (!response.ok) {
+    throw new Error(`Feed image upload failed. status: ${response.status}`);
+  }
+};

--- a/src/apis/feed/index.ts
+++ b/src/apis/feed/index.ts
@@ -10,6 +10,9 @@ export {
   getMyProfileTopInfoApi,
   getSavedFeedApi,
   getUserProfileTopInfoApi,
+  issuePresignedUrlApi,
+  uploadFeedImagesApi,
+  writeFeedApi,
 } from "./feed.api";
 
 export {
@@ -24,6 +27,7 @@ export {
   useGetMyProfileTopInfoQuery,
   useGetUserProfileTopInfoQuery,
   useSavedFeedQuery,
+  useWriteFeedMutation,
 } from "./feed.queries";
 
 export { FEED_QUERY_KEY } from "./feed.query-key";
@@ -44,4 +48,9 @@ export type {
   GetFeedUserProfileRequest,
   GetFeedUserProfileResponse,
   GetUserProfileTopInfoResponse,
+  IssuePresignedUrlRequest,
+  IssuePresignedUrlResponse,
+  WriteFeedMutationRequest,
+  WriteFeedRequest,
+  WriteFeedResponse,
 } from "./feed.types";

--- a/src/shared/ui/book-search-bottom-sheet/components/book-search-empty/index.tsx
+++ b/src/shared/ui/book-search-bottom-sheet/components/book-search-empty/index.tsx
@@ -1,19 +1,24 @@
 import { router } from "expo-router";
 import { useCallback } from "react";
-import { StyleSheet, View } from "react-native";
+import { ActivityIndicator, StyleSheet, View } from "react-native";
 
+import { type BookSelectableListType } from "@apis/book";
 import { colors } from "@theme/token";
 
 import AppText from "../../../app-text";
 import { CustomButton } from "../../../button";
 
 interface BookSearchEmptyProps {
+  isPending: boolean;
+  isError: boolean;
   searchText: string;
-  bookType: "SAVED" | "JOINING";
+  bookType: BookSelectableListType;
   handleClose: () => void;
 }
 
 export default function BookSearchEmpty({
+  isPending,
+  isError,
   searchText,
   bookType,
   handleClose,
@@ -25,30 +30,38 @@ export default function BookSearchEmpty({
 
   return (
     <View style={styles.emptyContainer}>
-      <AppText
-        weight="regular"
-        size="sm"
-        color={colors.grey[50]}
-        lineHeight={20}
-        style={{ textAlign: "center" }}
-      >
-        {searchText !== ""
-          ? `현재 등록된 책이 아닙니다.\n원하시는 책을 신청해주세요.`
-          : bookType === "SAVED"
-            ? `아직 저장한 책이 없어요.\n마음에 드는 책을 THIP 해보세요!`
-            : `아직 소속된 모임방이 없어요.\n마음에 드는 모임방에 참여해보세요!`}
-      </AppText>
-      {searchText !== "" && (
-        <CustomButton handlePress={handleToBookRequestPage}>
+      {isPending ? (
+        <ActivityIndicator size="large" color={colors.white} />
+      ) : (
+        <>
           <AppText
-            weight="semibold"
-            size="base"
-            color={colors.white}
-            lineHeight={24}
+            weight="regular"
+            size="sm"
+            color={colors.grey[50]}
+            lineHeight={20}
+            style={{ textAlign: "center" }}
           >
-            책 신청하기
+            {isError
+              ? "데이터를 불러오지 못했어요"
+              : searchText !== ""
+                ? `현재 등록된 책이 아닙니다.\n원하시는 책을 신청해주세요.`
+                : bookType === "SAVED"
+                  ? `아직 저장한 책이 없어요.\n마음에 드는 책을 THIP 해보세요!`
+                  : `아직 소속된 모임방이 없어요.\n마음에 드는 모임방에 참여해보세요!`}
           </AppText>
-        </CustomButton>
+          {searchText !== "" && (
+            <CustomButton handlePress={handleToBookRequestPage}>
+              <AppText
+                weight="semibold"
+                size="base"
+                color={colors.white}
+                lineHeight={24}
+              >
+                책 신청하기
+              </AppText>
+            </CustomButton>
+          )}
+        </>
       )}
     </View>
   );

--- a/src/shared/ui/book-search-bottom-sheet/components/book-search-empty/index.tsx
+++ b/src/shared/ui/book-search-bottom-sheet/components/book-search-empty/index.tsx
@@ -49,7 +49,7 @@ export default function BookSearchEmpty({
                   ? `아직 저장한 책이 없어요.\n마음에 드는 책을 THIP 해보세요!`
                   : `아직 소속된 모임방이 없어요.\n마음에 드는 모임방에 참여해보세요!`}
           </AppText>
-          {searchText !== "" && (
+          {!isError && searchText !== "" && (
             <CustomButton handlePress={handleToBookRequestPage}>
               <AppText
                 weight="semibold"

--- a/src/shared/ui/book-search-bottom-sheet/components/bottom-sheet-book-item/index.tsx
+++ b/src/shared/ui/book-search-bottom-sheet/components/bottom-sheet-book-item/index.tsx
@@ -2,12 +2,12 @@ import { Image, Pressable, StyleSheet } from "react-native";
 
 import { colors } from "@theme/token";
 
-import { FeedBookItemType } from "../..";
+import { type BottomSheetBookItemType } from "../..";
 import AppText from "../../../app-text";
 
 interface BottomSheetBookItemProps {
-  bookItem: FeedBookItemType;
-  handleSelectBook: (bookItem: FeedBookItemType) => void;
+  bookItem: BottomSheetBookItemType;
+  handleSelectBook: (bookItem: BottomSheetBookItemType) => void;
 }
 
 export default function BottomSheetBookItem({
@@ -20,7 +20,13 @@ export default function BottomSheetBookItem({
       onPress={() => handleSelectBook(bookItem)}
     >
       <Image source={{ uri: bookItem.bookImageUrl }} style={styles.bookImage} />
-      <AppText weight="regular" size="sm" color={colors.white} lineHeight={20}>
+      <AppText
+        style={styles.title}
+        weight="regular"
+        size="sm"
+        color={colors.white}
+        lineHeight={20}
+      >
         {bookItem.bookTitle}
       </AppText>
     </Pressable>
@@ -36,5 +42,8 @@ const styles = StyleSheet.create({
   bookImage: {
     width: 45,
     height: 60,
+  },
+  title: {
+    flexShrink: 1,
   },
 });

--- a/src/shared/ui/book-search-bottom-sheet/components/bottom-sheet-top-tab-bar/index.tsx
+++ b/src/shared/ui/book-search-bottom-sheet/components/bottom-sheet-top-tab-bar/index.tsx
@@ -1,6 +1,7 @@
 import { useRef } from "react";
 import { Animated, Easing, Pressable, StyleSheet, View } from "react-native";
 
+import { type BookSelectableListType } from "@apis/book";
 import { colors } from "@theme/token";
 
 import AppText from "../../../app-text";
@@ -10,8 +11,8 @@ const TAB_GAP = 20;
 const INDICATOR_MOVE_X = TAB_WIDTH + TAB_GAP;
 
 interface BottomSheetTopTabBarProps {
-  bookType: "SAVED" | "JOINING";
-  handleSetBookType: (type: "SAVED" | "JOINING") => void;
+  bookType: BookSelectableListType;
+  handleSetBookType: (type: BookSelectableListType) => void;
 }
 
 export default function BottomSheetTopTabBar({

--- a/src/shared/ui/book-search-bottom-sheet/index.tsx
+++ b/src/shared/ui/book-search-bottom-sheet/index.tsx
@@ -4,10 +4,16 @@ import BottomSheet, {
 } from "@gorhom/bottom-sheet";
 import { BlurView } from "expo-blur";
 import React, { useCallback, useRef, useState } from "react";
-import { Platform, StyleSheet, View } from "react-native";
+import { ActivityIndicator, Platform, StyleSheet, View } from "react-native";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
+import {
+  type BookSelectableListType,
+  type BookType,
+  useBookSelectableListQuery,
+  useSearchBookQuery,
+} from "@apis/book";
 import { colors } from "@theme/token";
 
 import SearchBar from "../search-bar";
@@ -16,14 +22,8 @@ import {
   BottomSheetBookItem,
   BottomSheetTopTabBar,
 } from "./components";
-import {
-  DUMMY_GROUP_BOOK_LIST_BOTTOM_SHEET,
-  DUMMY_SAVED_BOOK_LIST_BOTTOM_SHEET,
-  DUMMY_SEARCHED_BOOK_LIST_BOTTOM_SHEET,
-} from "./constants";
 
-// TODO: 서버 제공 타입으로 변경
-export interface FeedBookItemType {
+export interface BottomSheetBookItemType {
   bookTitle: string;
   authorName: string;
   bookImageUrl: string;
@@ -32,7 +32,7 @@ export interface FeedBookItemType {
 
 interface BookSearchBottomSheetProps {
   isVisible: boolean;
-  handleSelectBook: (bookItem: FeedBookItemType) => void;
+  handleSelectBook: (bookItem: BottomSheetBookItemType) => void;
   handleClose: () => void;
 }
 
@@ -43,11 +43,66 @@ export default function BookSearchBottomSheet({
 }: BookSearchBottomSheetProps) {
   const { bottom } = useSafeAreaInsets();
   const sheetRef = useRef<BottomSheet>(null);
-
-  const [bookType, setBookType] = useState<"SAVED" | "JOINING">("SAVED");
+  const [bookType, setBookType] = useState<BookSelectableListType>("SAVED");
   const [searchText, setSearchText] = useState("");
+  const trimmedSearchText = searchText.trim();
+  const isSearchMode = trimmedSearchText.length > 0;
 
-  const handleSetBookType = (type: "SAVED" | "JOINING") => {
+  const {
+    bookSelectableList,
+    fetchNextPage: fetchNextPageSelectableList,
+    hasNextPage: hasNextPageSelectableList,
+    isFetchingNextPage: isFetchingNextPageSelectableList,
+    isPendingBookSelectableList,
+    isErrorBookSelectableList,
+  } = useBookSelectableListQuery(bookType);
+
+  const {
+    searchBookList,
+    fetchNextPage: fetchNextPageSearchList,
+    hasNextPage: hasNextPageSearchList,
+    isFetchingNextPage: isFetchingNextPageSearchBook,
+    isPendingSearchBook,
+    isFetchingSearchBook,
+    isErrorSearchBook,
+  } = useSearchBookQuery(searchText, 1, false);
+
+  const searchResultBookList: BottomSheetBookItemType[] = searchBookList.map(
+    (item: BookType) => ({
+      bookTitle: item.title,
+      authorName: item.authorName,
+      bookImageUrl: item.imageUrl,
+      isbn: item.isbn,
+    }),
+  );
+
+  const bookList: BottomSheetBookItemType[] = isSearchMode
+    ? searchResultBookList
+    : bookSelectableList;
+  const isPendingBookList = isSearchMode
+    ? isPendingSearchBook
+    : isPendingBookSelectableList;
+  const isErrorBookList = isSearchMode
+    ? isErrorSearchBook
+    : isErrorBookSelectableList;
+  const isFetchingBookList = isSearchMode
+    ? isFetchingSearchBook
+    : isFetchingNextPageSelectableList;
+
+  const handleLoadMoreBookList = () => {
+    if (isSearchMode) {
+      if (!hasNextPageSearchList || isFetchingNextPageSearchBook) return;
+
+      fetchNextPageSearchList();
+      return;
+    }
+
+    if (!hasNextPageSelectableList || isFetchingNextPageSelectableList) return;
+
+    fetchNextPageSelectableList();
+  };
+
+  const handleSetBookType = (type: BookSelectableListType) => {
     setBookType(type);
   };
 
@@ -55,26 +110,13 @@ export default function BookSearchBottomSheet({
     setSearchText(text);
   }, []);
 
-  const handleSearch = useCallback(() => {
-    if (searchText.trim() === "") return;
-    console.log(searchText, " 검색");
-  }, [searchText]);
-
   const handlePressBook = useCallback(
-    (bookItem: FeedBookItemType) => {
+    (bookItem: BottomSheetBookItemType) => {
       handleSelectBook(bookItem);
       handleClose();
     },
     [handleSelectBook, handleClose],
   );
-
-  // TODO: 서버에서 받아온 값으로 수정. 로직도 약간 수정 필요.
-  const searchedBookList =
-    searchText.trim() !== ""
-      ? DUMMY_SEARCHED_BOOK_LIST_BOTTOM_SHEET
-      : bookType === "SAVED"
-        ? DUMMY_SAVED_BOOK_LIST_BOTTOM_SHEET
-        : DUMMY_GROUP_BOOK_LIST_BOTTOM_SHEET;
 
   return (
     isVisible && (
@@ -109,10 +151,12 @@ export default function BookSearchBottomSheet({
             value={searchText}
             placeholder="책 제목을 검색해보세요."
             setValue={handleChangeText}
-            handleSearch={handleSearch}
-            containerStyle={{ backgroundColor: colors.darkgrey.dark }}
+            containerStyle={[
+              { backgroundColor: colors.darkgrey.dark },
+              isSearchMode && { marginBottom: 20 },
+            ]}
           />
-          {searchText.trim() === "" && (
+          {!isSearchMode && (
             <BottomSheetTopTabBar
               bookType={bookType}
               handleSetBookType={handleSetBookType}
@@ -126,9 +170,9 @@ export default function BookSearchBottomSheet({
                   Platform.OS === "ios" ? bottom + 20 : bottom + 30,
               },
             ]}
-            data={searchedBookList}
-            keyExtractor={(item: FeedBookItemType) => String(item.isbn)}
-            renderItem={({ item }: { item: FeedBookItemType }) => (
+            data={bookList}
+            keyExtractor={(item: BottomSheetBookItemType) => String(item.isbn)}
+            renderItem={({ item }: { item: BottomSheetBookItemType }) => (
               <BottomSheetBookItem
                 bookItem={item}
                 handleSelectBook={handlePressBook}
@@ -137,11 +181,23 @@ export default function BookSearchBottomSheet({
             ItemSeparatorComponent={() => <View style={styles.separator} />}
             ListEmptyComponent={() => (
               <BookSearchEmpty
-                searchText={searchText.trim()}
+                isPending={isPendingBookList}
+                isError={isErrorBookList}
+                searchText={trimmedSearchText}
                 bookType={bookType}
                 handleClose={handleClose}
               />
             )}
+            ListFooterComponent={
+              isFetchingBookList ? (
+                <ActivityIndicator
+                  style={styles.footer}
+                  color={colors.white}
+                />
+              ) : null
+            }
+            onEndReached={handleLoadMoreBookList}
+            onEndReachedThreshold={0.5}
           />
         </BottomSheet>
       </GestureHandlerRootView>
@@ -169,5 +225,8 @@ const styles = StyleSheet.create({
     height: 1,
     backgroundColor: "#525252",
     marginTop: 12,
+  },
+  footer: {
+    marginTop: 40,
   },
 });

--- a/src/shared/ui/book-search-bottom-sheet/index.tsx
+++ b/src/shared/ui/book-search-bottom-sheet/index.tsx
@@ -63,7 +63,6 @@ export default function BookSearchBottomSheet({
     hasNextPage: hasNextPageSearchList,
     isFetchingNextPage: isFetchingNextPageSearchBook,
     isPendingSearchBook,
-    isFetchingSearchBook,
     isErrorSearchBook,
   } = useSearchBookQuery(searchText, 1, false);
 
@@ -86,7 +85,7 @@ export default function BookSearchBottomSheet({
     ? isErrorSearchBook
     : isErrorBookSelectableList;
   const isFetchingBookList = isSearchMode
-    ? isFetchingSearchBook
+    ? isFetchingNextPageSearchBook
     : isFetchingNextPageSelectableList;
 
   const handleLoadMoreBookList = () => {
@@ -190,10 +189,7 @@ export default function BookSearchBottomSheet({
             )}
             ListFooterComponent={
               isFetchingBookList ? (
-                <ActivityIndicator
-                  style={styles.footer}
-                  color={colors.white}
-                />
+                <ActivityIndicator style={styles.footer} color={colors.white} />
               ) : null
             }
             onEndReached={handleLoadMoreBookList}

--- a/src/shared/ui/book-select-section/index.tsx
+++ b/src/shared/ui/book-select-section/index.tsx
@@ -4,12 +4,12 @@ import { IcSearch } from "@images/icons";
 import { colors } from "@theme/token";
 
 import AppText from "../app-text";
-import { FeedBookItemType } from "../book-search-bottom-sheet";
+import { type BottomSheetBookItemType } from "../book-search-bottom-sheet";
 import { CustomButton } from "../button";
 
 interface BookSelectSectionProps {
   isAlreadySelected?: boolean;
-  book: FeedBookItemType | null;
+  book: BottomSheetBookItemType | null;
   handleOpenBottomSheet: () => void;
 }
 

--- a/src/shared/ui/index.ts
+++ b/src/shared/ui/index.ts
@@ -2,7 +2,7 @@ export { default as AppText } from "./app-text";
 export { default as BookInfoBar } from "./book-info-bar";
 export {
   default as BookSearchBottomSheet,
-  type FeedBookItemType,
+  type BottomSheetBookItemType,
 } from "./book-search-bottom-sheet";
 export { default as BookSelectSection } from "./book-select-section";
 export {

--- a/src/shared/ui/search-bar/index.tsx
+++ b/src/shared/ui/search-bar/index.tsx
@@ -16,7 +16,7 @@ interface SearchBarProps {
   placeholder: string;
   autoFocus?: boolean;
   setValue: (value: string) => void;
-  handleSearch: () => void;
+  handleSearch?: () => void;
   containerStyle?: StyleProp<ViewStyle>;
 }
 


### PR DESCRIPTION
## 📌 Related Issues

- close #96 

## 📄 Tasks

### 피드 작성 API 연동
- 피드 작성 시 선택한 책, 본문, 공개 여부, 태그, 이미지 정보를 서버로 전송하도록 연동했습니다.
- 이미지가 있는 경우 presigned URL을 발급받고, 각 이미지를 업로드한 뒤 반환된 fileUrl로 피드 작성 API를 호출하도록 처리했습니다.
- 피드 작성 완료 후 관련 스토어 정보를 초기화하고 이전 화면으로 이동하도록 반영했습니다.
- 작성 중에는 완료 버튼이 비활성화되도록 처리했습니다.

### 피드 작성 태그 조회 API 연동
- 기존 상수 기반 태그 목록을 제거하고 `/feeds/write-info` 응답 기반으로 카테고리와 태그를 표시하도록 변경했습니다.
- 태그 조회 실패 시 토스트를 노출하고, 필요한 경우 이전 화면으로 이동하도록 처리했습니다.

### BookSearchBottomSheet API 연동
- 기존 더미 데이터 기반 책 목록을 실제 API 기반으로 교체했습니다.
- 저장한 책 / 참여 중인 모임 책 목록을 `/books/selectable-list` API로 조회하도록 추가했습니다.
- 검색어 입력 시 책 검색 API 결과를 표시하도록 연동했습니다.
- 목록 pagination, loading footer, empty/error 상태를 추가했습니다.
- 검색 모드에서는 상단 탭을 숨기도록 UI 흐름을 정리했습니다.

### API 타입 및 쿼리 정리
- 피드 작성, presigned URL 발급, 책 선택 목록 관련 API 타입과 query hook을 추가했습니다.
- `FeedBookItemType`을 `BottomSheetBookItemType`으로 변경해 바텀시트 공용 타입 의미를 명확히 했습니다.
- 관련 endpoint/query key 명칭을 정리했습니다.
- 피드 작성 성공 시 피드 목록 query가 갱신되도록 처리했습니다.

## 변경 파일 요약
- `src/apis/feed/*`: 피드 작성, 이미지 업로드, 태그/쿼리 관련 로직 추가
- `src/apis/book/*`: 선택 가능한 책 목록 API 및 query 추가
- `screens/feed-write/*`: 피드 작성 화면 API 연동
- `src/shared/ui/book-search-bottom-sheet/*`: 책 검색 바텀시트 API 연동 및 상태 처리
- `screens/create-group/create-group-screen.tsx`: 변경된 책 선택 타입 반영


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 피드 작성 시 이미지 업로드 후 실제 게시 등록이 진행됩니다.
  * 책 선택 화면이 더 많은 도서를 불러오고(무한 스크롤), 검색 결과도 함께 확인할 수 있습니다.

* **버그 수정**
  * 그룹/피드 작성 간 책 선택 데이터가 더 정확하게 연동되도록 개선했습니다.
  * 태그 선택 목록이 최신 데이터 기준으로 표시되도록 변경했습니다.

* **개선**
  * 검색창 동작이 선택적으로 설정되어 더 유연하게 사용할 수 있습니다.
  * 로딩/오류 상태 안내가 추가되어 빈 화면과 실패 상황이 더 명확해졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->