### PR TITLE
[Feature/#120] 알림 읽음 처리 api 연동

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -12,7 +12,7 @@ import {
 import Toast from "react-native-toast-message";
 
 import { toastConfig } from "@config/toast.config";
-import { useLoadFonts } from "@shared/hooks";
+import { useLoadFonts, useNotificationHandler } from "@shared/hooks";
 import { colors } from "@theme/token";
 
 SplashScreen.preventAutoHideAsync();
@@ -26,6 +26,11 @@ Notifications.setNotificationHandler({
   }),
 });
 
+const NotificationHandler = () => {
+  useNotificationHandler();
+  return null;
+};
+
 // TODO: 추후 tabs 밖의 페이지들도 카테고리별로 묶기 / screens 폴더 내부도 카테고리별 묶기 필요
 
 export default function RootLayout() {
@@ -36,6 +41,7 @@ export default function RootLayout() {
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
       <QueryClientProvider client={queryClient}>
+        <NotificationHandler />
         <BottomSheetModalProvider>
           <SafeAreaView
             style={{ flex: 1, backgroundColor: colors.black.main }}

--- a/screens/alarm/components/alarm-item/index.tsx
+++ b/screens/alarm/components/alarm-item/index.tsx
@@ -1,6 +1,9 @@
 import { Pressable, StyleSheet, View } from "react-native";
 
-import { type NotificationItemType } from "@apis/notification";
+import {
+  useCheckNotification,
+  type NotificationItemType,
+} from "@apis/notification";
 import { AppText } from "@shared/ui";
 import { colors } from "@theme/token";
 
@@ -9,14 +12,24 @@ interface AlarmItemProps {
 }
 
 export default function AlarmItem({
-  alarm: { title, content, isChecked, notificationType, postDate },
+  alarm: {
+    title,
+    content,
+    isChecked,
+    notificationType,
+    postDate,
+    notificationId,
+  },
 }: AlarmItemProps) {
-  const displayTitle = title.replace(/^\[(피드|모임)\]\s*/, "");
+  const { checkNotification, isPendingCheckNotification } =
+    useCheckNotification();
 
-  // TODO: 추후 클릭 시 이동 및 읽음 처리 구현
   const handlePressAlarm = () => {
-    console.log(title, " 클릭");
+    if (isPendingCheckNotification) return null;
+    checkNotification({ notificationId });
   };
+
+  const displayTitle = title.replace(/^\[(피드|모임)\]\s*/, "");
 
   return (
     <Pressable

--- a/screens/feed-detail/feed-detail-screen.tsx
+++ b/screens/feed-detail/feed-detail-screen.tsx
@@ -221,7 +221,9 @@ export default function FeedDetailScreen() {
     <View style={[styles.page, { paddingBottom: bottom }]}>
       <FeedDetailHeader handlePressMore={handlePressMore} />
       <FlatList
-        ListHeaderComponent={() => <FeedPostDetail feedDetail={feedDetail} />}
+        ListHeaderComponent={() => (
+          <FeedPostDetail feedDetail={feedDetail} isDetailPage={true} />
+        )}
         contentContainerStyle={[styles.list, { paddingBottom: inputBarHeight }]}
         data={commentList}
         keyExtractor={(item) => String(item.commentId)}

--- a/src/apis/notification/index.ts
+++ b/src/apis/notification/index.ts
@@ -29,7 +29,6 @@ export type {
   GetUncheckedNotificationExistsResponse,
   NotificationItemType,
   NotificationRoute,
-  NotificationRouteParams,
   NotificationType,
   RegisterNotificationTokenRequest,
 } from "./notification.types";

--- a/src/apis/notification/notification.queries.ts
+++ b/src/apis/notification/notification.queries.ts
@@ -11,6 +11,8 @@ import Toast from "react-native-toast-message";
 
 import { getFormattedCurrentDateTime } from "@shared/utils";
 
+import { COMMENT_QUERY_KEY } from "../comment";
+import { FEED_QUERY_KEY } from "../feed";
 import {
   changePushNotificationStateApi,
   checkNotificationApi,
@@ -150,15 +152,41 @@ export const useCheckNotification = () => {
     error,
   } = useMutation<CheckNotificationResponse, Error, CheckNotificationRequest>({
     mutationFn: checkNotificationApi,
-    // TODO: 읽은 알림 타입에 맞춰 알맞은 페이지로 이동시키기
     onSuccess(data) {
       queryClient.invalidateQueries({
         queryKey: NOTIFICATION_QUERY_KEY.ALL,
       });
       if (data.route === NOTIFICATION_ROUTE.FEED_USER) {
-        // router.push({
-        //     pathname:"/"
-        // })
+        router.push({
+          pathname: "/user-profile/[userId]",
+          params: { userId: data.params.userId },
+        });
+      } else if (data.route === NOTIFICATION_ROUTE.FEED_DETAIL) {
+        router.push({
+          pathname: "/feed-detail/[feedId]",
+          params: { feedId: data.params.feedId },
+        });
+        queryClient.invalidateQueries({
+          queryKey: FEED_QUERY_KEY.DETAIL(data.params.feedId),
+        });
+        queryClient.invalidateQueries({
+          queryKey: COMMENT_QUERY_KEY.LIST(data.params.feedId, "FEED"),
+        });
+      } else if (
+        data.route === NOTIFICATION_ROUTE.ROOM_MAIN ||
+        data.route === NOTIFICATION_ROUTE.ROOM_DETAIL
+      ) {
+        // TODO: 추후 모임방 관련 시 쿼리 캐시 초기화 추가
+        router.push({
+          pathname: "/group-detail/[roomId]",
+          params: { roomId: data.params.roomId },
+        });
+      } else if (data.route === NOTIFICATION_ROUTE.ROOM_POST_DETAIL) {
+        // TODO: 이 경우에는 받은 params를 이용하여 해당 기록 위치를 보여주고, openComments 여부에 따라 댓글 바텀시트도 조작한다. 쿼리 캐시도 초기화
+        router.push({
+          pathname: "/group-detail/[roomId]",
+          params: { roomId: data.params.roomId },
+        });
       }
     },
   });

--- a/src/apis/notification/notification.types.ts
+++ b/src/apis/notification/notification.types.ts
@@ -1,4 +1,4 @@
-import { RoomPostType } from "../room";
+import type { RoomPostType } from "../room";
 
 export type NotificationType = "feed" | "room";
 
@@ -38,35 +38,36 @@ export interface CheckNotificationRequest {
   notificationId: number;
 }
 
-export type NotificationRoute =
-  | "FEED_USER"
-  | "FEED_DETAIL"
-  | "ROOM_MAIN"
-  | "ROOM_DETAIL"
-  | "ROOM_POST_DETAIL";
-
-export type NotificationRouteParams =
-  | {
-      userId: number;
-    }
-  | {
-      feedId: number;
-    }
-  | {
-      roomId: number;
-    }
-  | {
-      roomId: number;
-      page: number;
-      postId: number;
-      postType: RoomPostType;
-      openComments: boolean; // true:댓글에 대한 알림, false:댓글이 아닌 부분에 대한 알림
-    };
-
-export interface CheckNotificationResponse {
-  route: NotificationRoute;
-  params: NotificationRouteParams;
+export interface NotificationRouteParamMap {
+  FEED_USER: {
+    userId: number;
+  };
+  FEED_DETAIL: {
+    feedId: number;
+  };
+  ROOM_MAIN: {
+    roomId: number;
+  };
+  ROOM_DETAIL: {
+    roomId: number;
+  };
+  ROOM_POST_DETAIL: {
+    roomId: number;
+    page: number;
+    postId: number;
+    postType: RoomPostType;
+    openComments: boolean; // true:댓글에 대한 알림, false:댓글이 아닌 부분에 대한 알림
+  };
 }
+
+export type NotificationRoute = keyof NotificationRouteParamMap;
+
+export type CheckNotificationResponse = {
+  [Route in NotificationRoute]: {
+    route: Route;
+    params: NotificationRouteParamMap[Route];
+  };
+}[NotificationRoute];
 
 export interface ChangePushNotificationStateRequest {
   enable: boolean;

--- a/src/shared/hooks/index.ts
+++ b/src/shared/hooks/index.ts
@@ -1,3 +1,4 @@
 export { useKeyboardHeight } from "./use-keyboard-height";
 export { useLoadFonts } from "./use-load-fonts";
+export { useNotificationHandler } from "./use-notification-handler";
 export { usePreventAndroidBack } from "./use-prevent-android-back";

--- a/src/shared/hooks/use-notification-handler.ts
+++ b/src/shared/hooks/use-notification-handler.ts
@@ -1,0 +1,55 @@
+import * as Notifications from "expo-notifications";
+import { useEffect } from "react";
+
+import { useCheckNotification } from "@apis/notification";
+
+const parseNotificationId = (value: unknown) => {
+  if (typeof value === "number" && Number.isSafeInteger(value)) {
+    return value;
+  }
+
+  if (typeof value !== "string" || value.trim() === "") {
+    return null;
+  }
+
+  const notificationId = Number(value);
+
+  return Number.isSafeInteger(notificationId) ? notificationId : null;
+};
+
+const getNotificationIdFromResponse = (
+  response: Notifications.NotificationResponse,
+) => {
+  const { data } = response.notification.request.content;
+
+  return parseNotificationId(data.notificationId);
+};
+
+export const useNotificationHandler = () => {
+  const lastNotificationResponse = Notifications.useLastNotificationResponse();
+  const { checkNotification, isPendingCheckNotification } =
+    useCheckNotification();
+
+  useEffect(() => {
+    if (
+      !lastNotificationResponse ||
+      isPendingCheckNotification ||
+      lastNotificationResponse.actionIdentifier !==
+        Notifications.DEFAULT_ACTION_IDENTIFIER
+    ) {
+      return;
+    }
+
+    const notificationId = getNotificationIdFromResponse(
+      lastNotificationResponse,
+    );
+
+    if (notificationId == null) {
+      Notifications.clearLastNotificationResponse();
+      return;
+    }
+
+    checkNotification({ notificationId });
+    Notifications.clearLastNotificationResponse();
+  }, [checkNotification, isPendingCheckNotification, lastNotificationResponse]);
+};

--- a/src/shared/ui/feed-post/components/feed-post-footer/index.tsx
+++ b/src/shared/ui/feed-post/components/feed-post-footer/index.tsx
@@ -30,9 +30,13 @@ interface FeedPostFooterProps {
     | FeedMyPostPreviewType
     | FeedPostDetailType
     | FeedPostBase;
+  isDetailPage?: boolean;
 }
 
-export default function FeedPostFooter({ feed }: FeedPostFooterProps) {
+export default function FeedPostFooter({
+  feed,
+  isDetailPage = false,
+}: FeedPostFooterProps) {
   const { feedId, likeCount, commentCount, isLiked, isSaved, isWriter } = feed;
   const isChangingBookStatusRef = useRef(false);
   const { changeFeedSaveStatus, isPendingChangeFeedSaveStatus } =
@@ -84,7 +88,11 @@ export default function FeedPostFooter({ feed }: FeedPostFooterProps) {
           </AppText>
         </View>
         <View style={styles.likeCommentStyle}>
-          <Pressable onPress={handleToFeedDetail} hitSlop={5}>
+          <Pressable
+            onPress={handleToFeedDetail}
+            disabled={isDetailPage}
+            hitSlop={5}
+          >
             <IcComment />
           </Pressable>
           <AppText weight="medium" size="xs" color={colors.white}>

--- a/src/shared/ui/feed-post/feed-post-detail.tsx
+++ b/src/shared/ui/feed-post/feed-post-detail.tsx
@@ -12,9 +12,13 @@ import { FeedPostDetailType } from "./types";
 
 interface FeedPostDetailProps {
   feedDetail: FeedPostDetailType;
+  isDetailPage?: boolean;
 }
 
-export default function FeedPostDetail({ feedDetail }: FeedPostDetailProps) {
+export default function FeedPostDetail({
+  feedDetail,
+  isDetailPage = false,
+}: FeedPostDetailProps) {
   return (
     <View style={styles.container}>
       <FeedPostHeader feed={feedDetail} />
@@ -24,7 +28,7 @@ export default function FeedPostDetail({ feedDetail }: FeedPostDetailProps) {
         bookAuthor={feedDetail.bookAuthor}
       />
       <FeedPostDetailBody feedDetail={feedDetail} />
-      <FeedPostFooter feed={feedDetail} />
+      <FeedPostFooter feed={feedDetail} isDetailPage={isDetailPage} />
     </View>
   );
 }


### PR DESCRIPTION
## 📌 Related Issues

- close #120 

## 📄 Tasks

알림 읽음 처리 API(checkNotification)를 알림 아이템 클릭 흐름에 연결했습니다.
알림 목록의 AlarmItem 클릭 시 notificationId로 읽음 처리 API를 호출하고, 응답 route에 따라 화면 이동하도록 처리했습니다.
CheckNotificationResponse 타입을 route 기준 discriminated union으로 정리해, route별 params 접근 시 타입 에러가 나지 않도록 개선했습니다.
FEED_USER, FEED_DETAIL, ROOM_MAIN, ROOM_DETAIL, ROOM_POST_DETAIL route별 이동 처리를 추가했습니다.
FEED_DETAIL 알림 이동 시 피드 상세 캐시와 댓글 목록 캐시를 무효화하도록 처리했습니다.
푸시 알림 클릭 시에도 useCheckNotification을 사용해 알림 목록 클릭과 동일한 읽음 처리/라우팅 흐름을 타도록 useNotificationHandler를 추가했습니다.
앱 루트에서 NotificationHandler를 QueryClientProvider 내부에 연결했습니다.
피드 상세 화면에서 댓글 아이콘을 눌렀을 때 현재 상세 화면으로 다시 이동하지 않도록 isDetailPage 옵션을 추가했습니다.
알림 제목에서 [피드], [모임] prefix를 제거해서 표시하도록 처리했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 알림을 확인하면 관련 프로필, 피드, 모임 상세 화면으로 자동 이동합니다.
  * 알림에서 이동한 피드의 최신 내용과 댓글을 자동으로 갱신합니다.
  * 알람 항목을 눌러 알림을 확인하고 연결된 화면으로 이동할 수 있습니다.

* **버그 수정**
  * 알림 응답을 안정적으로 처리하고 중복 실행을 방지합니다.
  * 피드 상세 화면에서 댓글 수를 눌렀을 때 불필요한 재이동이 발생하지 않도록 수정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->