### PR TITLE
[Feature/#127/#129/#139 and Fix/#79]

### DIFF
--- a/screens/alarm/components/alarm-list/index.tsx
+++ b/screens/alarm/components/alarm-list/index.tsx
@@ -30,6 +30,7 @@ export default function AlarmList({ filter }: AlarmListProps) {
     isFetchingNextPage,
     isPendingNotificationList,
     isErrorNotificationList,
+    notificationListError,
     refetchNotificationList,
     isRefetchingNotificationList,
   } = useGetNotificationListQuery(filter);
@@ -52,7 +53,7 @@ export default function AlarmList({ filter }: AlarmListProps) {
     return (
       <View style={styles.status}>
         <AppText weight="semibold" size="lg" color={colors.white}>
-          데이터를 불러오지 못했어요
+          데이터를 불러오지 못했어요 ({notificationListError?.code})
         </AppText>
       </View>
     );

--- a/screens/book-recruiting-group/book-recruiting-group-screen.tsx
+++ b/screens/book-recruiting-group/book-recruiting-group-screen.tsx
@@ -25,6 +25,7 @@ export default function BookRecruitingGroupScreen() {
     isFetchingNextPage,
     isPendingBookRecruitingRooms,
     isErrorBookRecruitingRooms,
+    bookRecruitingRoomsError,
     refetchBookRecruitingRooms,
     isRefetchingBookRecruitingRooms,
   } = useBookRecruitingRoomsQuery(isbn);
@@ -45,18 +46,8 @@ export default function BookRecruitingGroupScreen() {
           color={colors.white}
           lineHeight={24}
         >
-          데이터를 불러오지 못했어요
+          데이터를 불러오지 못했어요 ({bookRecruitingRoomsError?.code})
         </AppText>
-        <Pressable onPress={() => void refetchBookRecruitingRooms()}>
-          <AppText
-            weight="regular"
-            size="sm"
-            color={colors.grey[100]}
-            lineHeight={20}
-          >
-            다시 시도하기
-          </AppText>
-        </Pressable>
       </View>
     );
   }

--- a/screens/feed/components/feed-contents/index.tsx
+++ b/screens/feed/components/feed-contents/index.tsx
@@ -1,3 +1,4 @@
+import { type RefObject } from "react";
 import {
   ActivityIndicator,
   FlatList,
@@ -13,8 +14,12 @@ import { colors } from "@theme/token";
 
 import MyThipPreview from "../my-thip-preview";
 
+interface FeedContentsProps {
+  listRef: RefObject<FlatList | null>;
+}
+
 // TODO: 추후 로딩 처리 스켈레톤으로 하기 / 로딩 인디케이터 고민하기
-export default function FeedContents() {
+export default function FeedContents({ listRef }: FeedContentsProps) {
   const {
     feedList,
     fetchNextPage,
@@ -70,6 +75,7 @@ export default function FeedContents() {
 
   return (
     <FlatList
+      ref={listRef}
       contentContainerStyle={[
         styles.list,
         isFetchingNextPage && { paddingBottom: 40 },

--- a/screens/feed/components/my-feed-contents/index.tsx
+++ b/screens/feed/components/my-feed-contents/index.tsx
@@ -1,3 +1,4 @@
+import { type RefObject } from "react";
 import {
   ActivityIndicator,
   FlatList,
@@ -59,7 +60,11 @@ const MyFeedTopContents = () => {
   );
 };
 
-export default function MyFeedContents() {
+interface MyFeedContentsProps {
+  listRef: RefObject<FlatList | null>;
+}
+
+export default function MyFeedContents({ listRef }: MyFeedContentsProps) {
   const {
     feedMyProfileList,
     fetchNextPage,
@@ -114,6 +119,7 @@ export default function MyFeedContents() {
 
   return (
     <FlatList
+      ref={listRef}
       contentContainerStyle={styles.list}
       ListHeaderComponent={<MyFeedTopContents />}
       data={feedMyProfileList}

--- a/screens/feed/feed-screen.tsx
+++ b/screens/feed/feed-screen.tsx
@@ -1,6 +1,7 @@
+import { useScrollToTop } from "@react-navigation/native";
 import { router, useLocalSearchParams } from "expo-router";
-import { useCallback, useState } from "react";
-import { Pressable, StyleSheet, View } from "react-native";
+import { useCallback, useRef, useState } from "react";
+import { FlatList, Pressable, StyleSheet, View } from "react-native";
 
 import { FloatingFeedWrite } from "@images/icons";
 
@@ -9,12 +10,35 @@ import { FeedContents, FeedTopTabBar, MyFeedContents } from "./components";
 export default function FeedScreen() {
   const { tab } = useLocalSearchParams<{ tab?: string }>();
   const [isMyFeed, setIsMyFeed] = useState(tab === "my-feed" ? true : false);
+  const listRef = useRef<FlatList>(null);
+  const tabPressRef = useRef({
+    scrollToTop: () => {},
+  });
+
+  const handleScrollToTop = () => {
+    listRef.current?.scrollToOffset({
+      offset: 0,
+      animated: true,
+    });
+  };
+
+  tabPressRef.current.scrollToTop = () => handleScrollToTop();
+
+  useScrollToTop(tabPressRef);
 
   const handleFeed = () => {
+    if (!isMyFeed) {
+      handleScrollToTop();
+      return;
+    }
     setIsMyFeed(false);
   };
 
   const handleMyFeed = () => {
+    if (isMyFeed) {
+      handleScrollToTop();
+      return;
+    }
     setIsMyFeed(true);
   };
 
@@ -29,7 +53,11 @@ export default function FeedScreen() {
         handleFeed={handleFeed}
         handleMyFeed={handleMyFeed}
       />
-      {isMyFeed ? <MyFeedContents /> : <FeedContents />}
+      {isMyFeed ? (
+        <MyFeedContents listRef={listRef} />
+      ) : (
+        <FeedContents listRef={listRef} />
+      )}
       <Pressable style={styles.floating} onPress={handleToWriteFeed}>
         <FloatingFeedWrite />
       </Pressable>

--- a/screens/group/components/group-header/index.tsx
+++ b/screens/group/components/group-header/index.tsx
@@ -2,11 +2,14 @@ import { router } from "expo-router";
 import { useCallback } from "react";
 import { Image, Pressable, StyleSheet, View } from "react-native";
 
-import { IcAlarm, IcDone } from "@images/icons";
+import { useGetUncheckedNotificationExistsQuery } from "@apis/notification";
+import { IcAlarm, IcDone, IcNoAlarm } from "@images/icons";
 import { ThipLogo } from "@images/thip";
 import { CustomHeader } from "@shared/ui";
 
 export default function GroupHeader() {
+  const { hasUncheckedNotification } = useGetUncheckedNotificationExistsQuery();
+
   const handleToCompletedGroup = useCallback(() => {
     router.push("/expired-group-list");
   }, []);
@@ -24,7 +27,7 @@ export default function GroupHeader() {
             <IcDone />
           </Pressable>
           <Pressable onPress={handleToAlarm} hitSlop={10}>
-            <IcAlarm />
+            {hasUncheckedNotification ? <IcAlarm /> : <IcNoAlarm />}
           </Pressable>
         </View>
       }

--- a/screens/saved/components/saved-book/index.tsx
+++ b/screens/saved/components/saved-book/index.tsx
@@ -33,6 +33,7 @@ export default function SavedBook() {
     isFetchingNextPage,
     isPendingSavedBook,
     isErrorSavedBook,
+    savedBookError,
     refetchSavedBook,
     isRefetchingSavedBook,
   } = useSavedBookQuery();
@@ -73,25 +74,15 @@ export default function SavedBook() {
 
   if (isErrorSavedBook && savedBookList.length === 0) {
     return (
-      <View style={styles.empty}>
+      <View style={[styles.empty, { height: height - 300 }]}>
         <AppText
           weight="semibold"
           size="lg"
           color={colors.white}
           lineHeight={24}
         >
-          데이터를 불러오지 못했어요
+          데이터를 불러오지 못했어요 ({savedBookError?.code})
         </AppText>
-        <Pressable onPress={() => void refetchSavedBook()}>
-          <AppText
-            weight="regular"
-            size="sm"
-            color={colors.grey[100]}
-            lineHeight={20}
-          >
-            다시 시도하기
-          </AppText>
-        </Pressable>
       </View>
     );
   }

--- a/screens/saved/components/saved-feed/index.tsx
+++ b/screens/saved/components/saved-feed/index.tsx
@@ -1,7 +1,6 @@
 import {
   ActivityIndicator,
   FlatList,
-  Pressable,
   RefreshControl,
   StyleSheet,
   useWindowDimensions,
@@ -24,6 +23,7 @@ export default function SavedFeed() {
     isFetchingNextPage,
     isPendingSavedFeed,
     isErrorSavedFeed,
+    savedFeedError,
     refetchSavedFeed,
     isRefetchingSavedFeed,
   } = useSavedFeedQuery();
@@ -44,25 +44,15 @@ export default function SavedFeed() {
 
   if (isErrorSavedFeed && savedFeedList.length === 0) {
     return (
-      <View style={styles.empty}>
+      <View style={[styles.empty, { height: height - 300 }]}>
         <AppText
           weight="semibold"
           size="lg"
           color={colors.white}
           lineHeight={24}
         >
-          데이터를 불러오지 못했어요
+          데이터를 불러오지 못했어요 ({savedFeedError?.code})
         </AppText>
-        <Pressable onPress={() => void refetchSavedFeed()}>
-          <AppText
-            weight="regular"
-            size="sm"
-            color={colors.grey[100]}
-            lineHeight={20}
-          >
-            다시 시도하기
-          </AppText>
-        </Pressable>
       </View>
     );
   }

--- a/screens/search-group/search-group-screen.tsx
+++ b/screens/search-group/search-group-screen.tsx
@@ -41,11 +41,11 @@ export default function SearchGroupScreen() {
     setRoomCategory(null);
   }, []);
 
-  const handleSearch = useCallback(() => {
-    if (searchText.trim() === "") return;
+  const handleSearch = useCallback((value: string) => {
+    if (value.trim() === "") return;
     setHasSearched(true);
     setRoomCategory("전체");
-  }, [searchText]);
+  }, []);
 
   const handleClickKeyword = useCallback((keyword: string) => {
     setSearchText(keyword);

--- a/screens/search-user/search-user-screen.tsx
+++ b/screens/search-user/search-user-screen.tsx
@@ -26,10 +26,10 @@ export default function SearchUserScreen() {
     setHasSearched(false);
   }, []);
 
-  const handleSearch = useCallback(() => {
-    if (searchText.trim() === "") return;
+  const handleSearch = useCallback((value: string) => {
+    if (value.trim() === "") return;
     setHasSearched(true);
-  }, [searchText]);
+  }, []);
 
   const handleClickKeyword = useCallback((keyword: string) => {
     setSearchText(keyword);

--- a/screens/search/components/most-searched/index.tsx
+++ b/screens/search/components/most-searched/index.tsx
@@ -12,6 +12,7 @@ export default function MostSearched() {
     mostSearchedBookData,
     isPendingMostSearchedBook,
     isErrorMostSearchedBook,
+    mostSearchedBookError,
   } = useMostSearchedBookQuery();
 
   const dateString = useMemo(() => {
@@ -39,7 +40,7 @@ export default function MostSearched() {
       ) : isErrorMostSearchedBook ? (
         <View style={styles.emptyContainer}>
           <AppText weight="semibold" size="lg" color={colors.white}>
-            데이터를 불러오지 못했어요
+            데이터를 불러오지 못했어요 ({mostSearchedBookError?.code})
           </AppText>
         </View>
       ) : mostSearchedBookData?.bookList.length === 0 ? (

--- a/screens/search/search-screen.tsx
+++ b/screens/search/search-screen.tsx
@@ -27,10 +27,10 @@ export default function SearchScreen() {
     setHasSearched(false);
   }, []);
 
-  const handleSearch = useCallback(() => {
-    if (searchText.trim() === "") return;
+  const handleSearch = useCallback((value: string) => {
+    if (value.trim() === "") return;
     setHasSearched(true);
-  }, [searchText]);
+  }, []);
 
   const handleClickKeyword = useCallback((keyword: string) => {
     setSearchText(keyword);

--- a/src/apis/book/book.queries.ts
+++ b/src/apis/book/book.queries.ts
@@ -5,10 +5,11 @@ import {
   useQuery,
   useQueryClient,
 } from "@tanstack/react-query";
+import { router } from "expo-router";
 import { useEffect } from "react";
 import Toast from "react-native-toast-message";
 
-import { router } from "expo-router";
+import { ApiErrorResponse } from "../api-client";
 import {
   changeBookSaveStatusApi,
   getBookDetailApi,
@@ -151,7 +152,8 @@ export const useMostSearchedBookQuery = () => {
     data: mostSearchedBookData,
     isPending: isPendingMostSearchedBook,
     isError: isErrorMostSearchedBook,
-  } = useQuery<GetMostSearchedBookResponse, Error>({
+    error: mostSearchedBookError,
+  } = useQuery<GetMostSearchedBookResponse, ApiErrorResponse>({
     queryKey: BOOK_QUERY_KEY.MOST,
     queryFn: getMostSearchedBookApi,
     staleTime: MOST_SEARCHED_BOOK_QUERY_CACHE_TIME.STALE,
@@ -162,6 +164,7 @@ export const useMostSearchedBookQuery = () => {
     mostSearchedBookData,
     isPendingMostSearchedBook,
     isErrorMostSearchedBook,
+    mostSearchedBookError,
   };
 };
 
@@ -205,7 +208,7 @@ export const useSavedBookQuery = () => {
     isRefetching: isRefetchingSavedBook,
   } = useInfiniteQuery<
     GetSavedBookResponse,
-    Error,
+    ApiErrorResponse,
     InfiniteData<GetSavedBookResponse, SavedBookCursor>,
     typeof BOOK_QUERY_KEY.SAVED,
     SavedBookCursor
@@ -235,6 +238,7 @@ export const useSavedBookQuery = () => {
     isFetchingNextPage,
     isPendingSavedBook,
     isErrorSavedBook,
+    savedBookError,
     refetchSavedBook,
     isRefetchingSavedBook,
   };
@@ -255,7 +259,7 @@ export const useBookRecruitingRoomsQuery = (isbn: string) => {
     isRefetching: isRefetchingBookRecruitingRooms,
   } = useInfiniteQuery<
     GetBookRecruitingRoomsResponse,
-    Error,
+    ApiErrorResponse,
     InfiniteData<GetBookRecruitingRoomsResponse, BookRecruitingRoomCursor>,
     ReturnType<typeof BOOK_QUERY_KEY.RECRUITING>,
     BookRecruitingRoomCursor
@@ -291,6 +295,7 @@ export const useBookRecruitingRoomsQuery = (isbn: string) => {
     isFetchingNextPage,
     isPendingBookRecruitingRooms,
     isErrorBookRecruitingRooms,
+    bookRecruitingRoomsError,
     refetchBookRecruitingRooms,
     isRefetchingBookRecruitingRooms,
   };

--- a/src/apis/feed/feed.queries.ts
+++ b/src/apis/feed/feed.queries.ts
@@ -9,6 +9,7 @@ import { router } from "expo-router";
 import { useEffect } from "react";
 import Toast from "react-native-toast-message";
 
+import { ApiErrorResponse } from "../api-client";
 import {
   changeFeedLikeStatusApi,
   changeFeedSaveStatusApi,
@@ -404,7 +405,7 @@ export const useSavedFeedQuery = () => {
     isRefetching: isRefetchingSavedFeed,
   } = useInfiniteQuery<
     GetFeedListResponse,
-    Error,
+    ApiErrorResponse,
     InfiniteData<GetFeedListResponse, FeedCursor>,
     typeof FEED_QUERY_KEY.SAVED,
     FeedCursor
@@ -434,6 +435,7 @@ export const useSavedFeedQuery = () => {
     isFetchingNextPage,
     isPendingSavedFeed,
     isErrorSavedFeed,
+    savedFeedError,
     refetchSavedFeed,
     isRefetchingSavedFeed,
   };

--- a/src/apis/notification/notification.queries.ts
+++ b/src/apis/notification/notification.queries.ts
@@ -12,6 +12,7 @@ import Toast from "react-native-toast-message";
 
 import { getFormattedCurrentDateTime } from "@shared/utils";
 
+import { ApiErrorResponse } from "../api-client";
 import { COMMENT_QUERY_KEY } from "../comment";
 import { FEED_QUERY_KEY } from "../feed";
 import {
@@ -25,16 +26,16 @@ import {
 } from "./notification.api";
 import { NOTIFICATION_ROUTE } from "./notification.constant";
 import { NOTIFICATION_QUERY_KEY } from "./notification.query-key";
-import {
+import type {
   ChangePushNotificationStateRequest,
   ChangePushNotificationStateResponse,
+  CheckNotificationRequest,
+  CheckNotificationResponse,
+  GetNotificationListResponse,
   GetPushNotificationStateResponse,
-  type CheckNotificationRequest,
-  type CheckNotificationResponse,
-  type GetNotificationListResponse,
-  type GetUncheckedNotificationExistsResponse,
-  type NotificationType,
-  type RegisterNotificationTokenRequest,
+  GetUncheckedNotificationExistsResponse,
+  NotificationType,
+  RegisterNotificationTokenRequest,
 } from "./notification.types";
 
 type NotificationCursor = string | null;
@@ -47,12 +48,12 @@ export const useGetNotificationListQuery = (type: NotificationType | null) => {
     isFetchingNextPage,
     isPending: isPendingNotificationList,
     isError: isErrorNotificationList,
-    error,
+    error: notificationListError,
     refetch: refetchNotificationList,
     isRefetching: isRefetchingNotificationList,
   } = useInfiniteQuery<
     GetNotificationListResponse,
-    Error,
+    ApiErrorResponse,
     InfiniteData<GetNotificationListResponse, NotificationCursor>,
     ReturnType<typeof NOTIFICATION_QUERY_KEY.LIST>,
     NotificationCursor
@@ -69,13 +70,13 @@ export const useGetNotificationListQuery = (type: NotificationType | null) => {
   });
 
   useEffect(() => {
-    if (!isErrorNotificationList || !error) return;
+    if (!isErrorNotificationList || !notificationListError) return;
 
     Toast.show({
       type: "error",
-      text1: error.message,
+      text1: notificationListError.message,
     });
-  }, [isErrorNotificationList, error]);
+  }, [isErrorNotificationList, notificationListError]);
 
   return {
     notificationList: data?.pages.flatMap((page) => page.notifications) ?? [],
@@ -84,6 +85,7 @@ export const useGetNotificationListQuery = (type: NotificationType | null) => {
     isFetchingNextPage,
     isPendingNotificationList,
     isErrorNotificationList,
+    notificationListError,
     refetchNotificationList,
     isRefetchingNotificationList,
   };

--- a/src/shared/ui/chat-input-bar/index.tsx
+++ b/src/shared/ui/chat-input-bar/index.tsx
@@ -64,10 +64,13 @@ export default function ChatInputBar({
 
   const ableToSend = text.trim().length !== 0 && !isPendingSend;
 
+  const keyboardVerticalOffset =
+    Platform.OS === "ios" ? 36 : isFocus ? bottom : 0;
+
   return (
     <KeyboardAvoidingView
       behavior={"padding"}
-      keyboardVerticalOffset={isFocus ? bottom : 0}
+      keyboardVerticalOffset={keyboardVerticalOffset}
       style={styles.container}
       onLayout={onLayout}
     >

--- a/src/shared/ui/comment-list/comment-item.tsx
+++ b/src/shared/ui/comment-list/comment-item.tsx
@@ -151,7 +151,10 @@ export default function CommentItem({
 }
 
 const styles = StyleSheet.create({
-  replyContainer: { flexDirection: "row", gap: 8 },
+  replyContainer: {
+    flexDirection: "row",
+    gap: 8,
+  },
   container: { gap: 12, flex: 1 },
   header: {
     flexDirection: "row",

--- a/src/shared/ui/comment-list/comment-root.tsx
+++ b/src/shared/ui/comment-list/comment-root.tsx
@@ -28,7 +28,10 @@ export default function CommentRoot({
       {comment.replyList.length !== 0 && (
         <FlatList
           data={comment.replyList}
-          style={styles.replyList}
+          style={[
+            styles.replyList,
+            { marginBottom: postType === "FEED" ? 0 : 10 },
+          ]}
           renderItem={({ item }) => (
             <CommentItem
               postId={postId}

--- a/src/shared/ui/custom-tab-bar/index.tsx
+++ b/src/shared/ui/custom-tab-bar/index.tsx
@@ -30,10 +30,22 @@ export default function CustomTabBar({
               ? options.tabBarIcon({ focused, color, size })
               : null;
 
+          const handleTabPress = () => {
+            const event = navigation.emit({
+              type: "tabPress",
+              target: route.key,
+              canPreventDefault: true,
+            });
+
+            if (!focused && !event.defaultPrevented) {
+              navigation.navigate(route.name, route.params);
+            }
+          };
+
           return (
             <Pressable
               key={route.key}
-              onPress={() => navigation.navigate(route.name)}
+              onPress={handleTabPress}
               style={styles.tabBarItemContainer}
             >
               <View style={styles.tabBarItemIcon}>{icon}</View>

--- a/src/shared/ui/search-bar/index.tsx
+++ b/src/shared/ui/search-bar/index.tsx
@@ -74,7 +74,7 @@ export default function SearchBar({
         hitSlop={10}
       />
       <View style={styles.buttonWrapper}>
-        {!!inputValue.trim() && (
+        {inputValue.length > 0 && (
           <Pressable onPress={handleDelete}>
             <IcXCircle />
           </Pressable>

--- a/src/shared/ui/search-bar/index.tsx
+++ b/src/shared/ui/search-bar/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useEffect, useState } from "react";
 import {
   Pressable,
   StyleProp,
@@ -11,12 +11,14 @@ import {
 import { IcSearch, IcXCircle } from "@images/icons";
 import { colors, typography } from "@theme/token";
 
+const SEARCH_DEBOUNCE_DELAY = 300;
+
 interface SearchBarProps {
   value: string;
   placeholder: string;
   autoFocus?: boolean;
   setValue: (value: string) => void;
-  handleSearch?: () => void;
+  handleSearch?: (value: string) => void;
   containerStyle?: StyleProp<ViewStyle>;
 }
 
@@ -28,31 +30,56 @@ export default function SearchBar({
   handleSearch,
   containerStyle,
 }: SearchBarProps) {
+  const [inputValue, setInputValue] = useState(value);
+
+  useEffect(() => {
+    setInputValue(value);
+  }, [value]);
+
+  useEffect(() => {
+    if (inputValue === value) {
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      setValue(inputValue);
+    }, SEARCH_DEBOUNCE_DELAY);
+
+    return () => clearTimeout(timer);
+  }, [inputValue, setValue, value]);
+
   const handleDelete = useCallback(() => {
+    setInputValue("");
     setValue("");
   }, [setValue]);
+
+  const handleSubmit = useCallback(() => {
+    setValue(inputValue);
+    handleSearch?.(inputValue);
+  }, [handleSearch, inputValue, setValue]);
+
   return (
     <View style={[styles.container, containerStyle]}>
       <TextInput
         style={styles.input}
-        value={value}
-        onChangeText={setValue}
+        value={inputValue}
+        onChangeText={setInputValue}
         placeholder={placeholder}
         placeholderTextColor={colors.grey[300]}
         selectionColor={colors.neongreen}
         cursorColor={colors.neongreen}
         returnKeyType="search"
-        onSubmitEditing={handleSearch}
+        onSubmitEditing={handleSubmit}
         autoFocus={autoFocus}
         hitSlop={10}
       />
       <View style={styles.buttonWrapper}>
-        {!!value.trim() && (
+        {!!inputValue.trim() && (
           <Pressable onPress={handleDelete}>
             <IcXCircle />
           </Pressable>
         )}
-        <Pressable onPress={handleSearch}>
+        <Pressable onPress={handleSubmit}>
           <IcSearch />
         </Pressable>
       </View>


### PR DESCRIPTION
## 📌 Related Issues

- close #79 
- close #127 
- close #129 
- close #139 

## 📄 Tasks

- iOS에서 댓글 바텀시트 및 채팅 입력창의 키보드 위치 보정
- 댓글 대댓글 목록의 화면별 하단 여백 조정
- 모임 헤더에서 미확인 알림 여부에 따라 알림 아이콘 변경
- 피드 상단 탭을 다시 누르면 현재 피드 목록을 최상단으로 이동
- 하단 피드 탭을 다시 누르면 `tabPress` 이벤트를 통해 최상단으로 이동
- 일반 피드와 내 피드 `FlatList`를 동일한 ref로 제어
- 알림, 저장한 책·피드, 모집 중인 모임방, 인기 검색 도서 조회 오류에 서버 에러 코드 표시
- API 쿼리 에러 타입을 `ApiErrorResponse`로 변경하여 에러 코드 사용
- 일부 에러 화면의 불필요한 다시 시도 버튼 제거 및 화면 높이 보정
- 공용 `SearchBar`에 300ms 디바운싱 적용
- 검색 버튼 및 키보드 검색 실행 시 현재 입력값을 즉시 반영하도록 개선

## 🔍 PR Point (To Reviewer)

- `CustomTabBar`에서 직접 화면만 이동하던 로직을 `tabPress` 이벤트를 발생시키도록 변경했습니다.
- 현재 선택된 피드 탭을 다시 누르면 목록이 최상단으로 이동하며, 다른 피드 탭을 선택하면 기존처럼 목록이 전환됩니다.
- `SearchBar`는 입력 UI를 즉시 갱신하지만 부모 검색어 상태는 300ms 뒤에 반영합니다.
- 검색 버튼 또는 키보드 검색을 누른 경우에는 디바운싱 대기 없이 현재 입력값으로 즉시 검색합니다.
- 검색 화면의 `handleSearch`는 디바운싱 중 이전 검색어를 참조하지 않도록 현재 입력값을 인자로 받습니다.
- iOS 채팅 입력창에는 플랫폼별 `keyboardVerticalOffset`을 적용했습니다.
- 조회 실패 화면에서 서버 에러 코드를 함께 확인할 수 있습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 피드 화면에서 현재 탭을 다시 누르면 목록이 맨 위로 이동합니다.
  - 읽지 않은 알림이 있을 때 알림 아이콘이 구분되어 표시됩니다.
  - 검색어 입력이 안정적으로 반영되고, 검색 실행 시 최신 입력값이 사용됩니다.

- **버그 수정**
  - 알림, 저장 콘텐츠, 모집방 등 데이터 조회 실패 시 오류 코드가 함께 표시됩니다.
  - 채팅 입력창의 iOS 키보드 대응과 댓글 목록 여백을 개선했습니다.
  - 탭 이동 동작이 더욱 자연스럽게 처리됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->