### PR TITLE
[Feature/#145] 모임방 관련 command api 사용

### DIFF
--- a/screens/group-detail/group-detail-screen.tsx
+++ b/screens/group-detail/group-detail-screen.tsx
@@ -95,15 +95,27 @@ export default function GroupDetailScreen() {
         type: "default",
         text1: "모임방을 성공적으로 삭제했어요.",
       });
+      // TODO: 성공했을 때만 사용되도록
+      if (router.canGoBack()) {
+        router.back();
+      } else {
+        router.push("/group");
+      }
     }
     if (modalType === "leave") {
       if (isPendingLeaveRoom) return;
-      leaveRoom({ roomId: roomDetailData.roomId });
-    }
-    if (router.canGoBack()) {
-      router.back();
-    } else {
-      router.push("/group");
+      leaveRoom(
+        { roomId: roomDetailData.roomId },
+        {
+          onSuccess: () => {
+            if (router.canGoBack()) {
+              router.back();
+            } else {
+              router.push("/group");
+            }
+          },
+        },
+      );
     }
   };
 

--- a/screens/group-detail/group-detail-screen.tsx
+++ b/screens/group-detail/group-detail-screen.tsx
@@ -10,7 +10,7 @@ import {
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import Toast from "react-native-toast-message";
 
-import { useGetRoomDetailQuery } from "@apis/room";
+import { useGetRoomDetailQuery, useLeaveRoomMutation } from "@apis/room";
 import { AppText, GroupInfo } from "@shared/ui";
 import { colors } from "@theme/token";
 
@@ -39,6 +39,7 @@ export default function GroupDetailScreen() {
     refetchRoomDetail,
     isRefetchingRoomDetail,
   } = useGetRoomDetailQuery(roomId);
+  const { leaveRoom, isPendingLeaveRoom } = useLeaveRoomMutation();
 
   const handleToReadingMateList = () => {
     router.push({
@@ -66,7 +67,7 @@ export default function GroupDetailScreen() {
     setIsBottomSheetVisible(false);
   };
 
-  // TODO: 서버에 요청
+  // TODO: 서버에 신고 요청
   const handleReportGroup = () => {
     setIsBottomSheetVisible(false);
     Toast.show({
@@ -85,9 +86,10 @@ export default function GroupDetailScreen() {
     setModalType(null);
   };
 
-  // TODO: 서버에 요청
   const handleModalAccept = () => {
+    if (!roomDetailData) return;
     handleCloseModal();
+    // TODO: 서버에 삭제 요청
     if (modalType === "delete") {
       Toast.show({
         type: "default",
@@ -95,10 +97,8 @@ export default function GroupDetailScreen() {
       });
     }
     if (modalType === "leave") {
-      Toast.show({
-        type: "default",
-        text1: "모임 나가기를 완료했어요.",
-      });
+      if (isPendingLeaveRoom) return;
+      leaveRoom({ roomId: roomDetailData.roomId });
     }
     if (router.canGoBack()) {
       router.back();

--- a/screens/join-group/components/join-password/index.tsx
+++ b/screens/join-group/components/join-password/index.tsx
@@ -1,12 +1,13 @@
 import { useEffect, useRef, useState } from "react";
 import { Keyboard, Pressable, StyleSheet, TextInput, View } from "react-native";
-import Toast from "react-native-toast-message";
 
+import {
+  type ChangeRoomJoinStatusRequest,
+  useVerifyPrivateRoomPassword,
+} from "@apis/room";
 import { IcArrowLeft } from "@images/icons";
 import { AppText } from "@shared/ui";
 import { colors } from "@theme/token";
-
-import { DUMMY_GROUP_PASSWORD } from "../../constants";
 
 const PASSWORD_LENGTH = 4;
 const PASSWORD_INPUT_INDICES = Array.from(
@@ -18,51 +19,68 @@ interface JoinPasswordProps {
   roomId: number;
   isOpen: boolean;
   handleClose: () => void;
+  changeRoomJoinStatus: ({ roomId, type }: ChangeRoomJoinStatusRequest) => void;
 }
 
 export default function JoinPassword({
-  // roomId, 추후 서버에 해당 id로 요청
+  roomId,
   isOpen,
   handleClose,
+  changeRoomJoinStatus,
 }: JoinPasswordProps) {
   const inputRefs = useRef<(TextInput | null)[]>([]);
   const [password, setPassword] = useState<string[]>(
     Array(PASSWORD_LENGTH).fill(""),
   );
+  const [isError, setIsError] = useState(false);
+
+  const { verifyPrivateRoomPassword, isPendingVerifyPrivateRoomPassword } =
+    useVerifyPrivateRoomPassword();
 
   const handleChangePassword = (index: number, text: string) => {
     const value = text.slice(-1);
     const nextPassword = [...password];
     nextPassword[index] = value;
 
+    setIsError(false);
     setPassword(nextPassword);
 
     if (value && index < PASSWORD_LENGTH - 1) {
       inputRefs.current[index + 1]?.focus();
     }
-
-    if (value && index === PASSWORD_LENGTH - 1) {
-      console.log(...nextPassword);
-    }
   };
 
   const allInput = password.join("");
 
-  // TODO: 추후 서버에서 온 응답으로 수정
-  const isError = allInput.length === 4 && allInput !== DUMMY_GROUP_PASSWORD;
-
   useEffect(() => {
-    if (allInput.length === 4) {
-      // TODO : 서버에 비밀번호 요청
-      if (!isError) {
-        Toast.show({
-          type: "default",
-          text1: "모임방 참여가 완료되었어요! 모집 마감 후 활동이 시작돼요.",
-        });
-        handleClose();
-      }
+    if (allInput.length === 4 && !isPendingVerifyPrivateRoomPassword) {
+      verifyPrivateRoomPassword(
+        { roomId, password: allInput },
+        {
+          onSuccess: (data) => {
+            if (data.matched) {
+              changeRoomJoinStatus({
+                roomId,
+                type: "join",
+              });
+              handleClose();
+              setIsError(false);
+              setPassword([]);
+            } else {
+              setIsError(true);
+            }
+          },
+        },
+      );
     }
-  }, [allInput, isError, handleClose]);
+  }, [
+    roomId,
+    allInput,
+    isPendingVerifyPrivateRoomPassword,
+    changeRoomJoinStatus,
+    verifyPrivateRoomPassword,
+    handleClose,
+  ]);
 
   return (
     isOpen && (

--- a/screens/join-group/components/join-password/index.tsx
+++ b/screens/join-group/components/join-password/index.tsx
@@ -51,9 +51,15 @@ export default function JoinPassword({
   };
 
   const allInput = password.join("");
+  const lastVerifiedInputRef = useRef<string | null>(null);
 
   useEffect(() => {
-    if (allInput.length === 4 && !isPendingVerifyPrivateRoomPassword) {
+    if (
+      allInput.length === 4 &&
+      !isPendingVerifyPrivateRoomPassword &&
+      lastVerifiedInputRef.current !== allInput
+    ) {
+      lastVerifiedInputRef.current = allInput;
       verifyPrivateRoomPassword(
         { roomId, password: allInput },
         {
@@ -65,7 +71,7 @@ export default function JoinPassword({
               });
               handleClose();
               setIsError(false);
-              setPassword([]);
+              setPassword(Array(PASSWORD_LENGTH).fill(""));
             } else {
               setIsError(true);
             }

--- a/screens/join-group/constants/index.ts
+++ b/screens/join-group/constants/index.ts
@@ -1,1 +1,0 @@
-export const DUMMY_GROUP_PASSWORD = "1234";

--- a/screens/join-group/join-group-screen.tsx
+++ b/screens/join-group/join-group-screen.tsx
@@ -94,7 +94,6 @@ export default function JoinGroupScreen() {
     recruitingRoomDetailData?.memberCount ===
     recruitingRoomDetailData?.recruitCount;
 
-  // TODO: 연동 필요
   const handlePressJoinButton = useCallback(() => {
     if (isPendingChangeRoomJoinStatus) return;
     if (isRecruitingFull) {

--- a/screens/join-group/join-group-screen.tsx
+++ b/screens/join-group/join-group-screen.tsx
@@ -263,6 +263,7 @@ export default function JoinGroupScreen() {
             roomId={recruitingRoomDetailData.roomId}
             isOpen={isPasswordOpen}
             handleClose={handleClosePassword}
+            changeRoomJoinStatus={changeRoomJoinStatus}
           />
         </>
       )}

--- a/screens/join-group/join-group-screen.tsx
+++ b/screens/join-group/join-group-screen.tsx
@@ -18,7 +18,11 @@ import {
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import Toast from "react-native-toast-message";
 
-import { useGetRecruitingRoomDetailQuery } from "@apis/room";
+import {
+  useChangeRoomJoinStatusMutation,
+  useCloseRoomRecruitingMutation,
+  useGetRecruitingRoomDetailQuery,
+} from "@apis/room";
 import { AppText, GroupInfo } from "@shared/ui";
 import { colors } from "@theme/token";
 
@@ -81,6 +85,10 @@ export default function JoinGroupScreen() {
     refetchRecruitingRoomDetail,
     isRefetchingRecruitingRoomDetail,
   } = useGetRecruitingRoomDetailQuery(roomId);
+  const { changeRoomJoinStatus, isPendingChangeRoomJoinStatus } =
+    useChangeRoomJoinStatusMutation();
+  const { closeRoomRecruiting, isPendingCloseRoomRecruiting } =
+    useCloseRoomRecruitingMutation();
 
   const isRecruitingFull =
     recruitingRoomDetailData?.memberCount ===
@@ -88,6 +96,7 @@ export default function JoinGroupScreen() {
 
   // TODO: 연동 필요
   const handlePressJoinButton = useCallback(() => {
+    if (isPendingChangeRoomJoinStatus) return;
     if (isRecruitingFull) {
       Toast.show({
         type: "default",
@@ -95,7 +104,6 @@ export default function JoinGroupScreen() {
       });
       return;
     }
-    // TODO: 모집 마감 및 참여 취소 모달 추가 필요 / roomId로 신청 및 해제
     if (recruitingRoomDetailData?.isHost) {
       setIsFinishModalOpen(true);
     } else if (recruitingRoomDetailData?.isJoining) {
@@ -103,39 +111,65 @@ export default function JoinGroupScreen() {
     } else if (!recruitingRoomDetailData?.isPublic) {
       setIsPasswordOpen(true);
     } else {
-      Toast.show({
-        type: "default",
-        text1: "모임방 참여가 완료되었어요!",
+      changeRoomJoinStatus({
+        roomId: recruitingRoomDetailData.roomId,
+        type: "join",
       });
     }
-  }, [recruitingRoomDetailData, isRecruitingFull]);
+  }, [
+    recruitingRoomDetailData,
+    isRecruitingFull,
+    isPendingChangeRoomJoinStatus,
+    changeRoomJoinStatus,
+  ]);
 
   const handleCloseCancelModal = useCallback(() => {
     setIsCancelModalOpen(false);
   }, []);
 
-  // TODO: 연동 필요
   const handleCancelJoin = useCallback(() => {
-    setIsCancelModalOpen(false);
-    router.push("/group");
-    Toast.show({
-      type: "default",
-      text1: "모임방 참여가 취소되었어요! 다른 방을 찾아보세요.",
-    });
-  }, []);
+    if (!recruitingRoomDetailData || isPendingChangeRoomJoinStatus) return;
+    changeRoomJoinStatus(
+      {
+        roomId: recruitingRoomDetailData.roomId,
+        type: "cancel",
+      },
+      {
+        onSuccess: () => {
+          setIsCancelModalOpen(false);
+          if (router.canGoBack()) {
+            router.back();
+          } else {
+            router.push("/group");
+          }
+        },
+      },
+    );
+  }, [
+    changeRoomJoinStatus,
+    recruitingRoomDetailData,
+    isPendingChangeRoomJoinStatus,
+  ]);
 
   const handleCloseFinishModal = useCallback(() => {
     setIsFinishModalOpen(false);
   }, []);
 
-  // TODO: 서버에 요청 성공 시 토스트 띄우고 모임방 상세 페이지로 이동
   const handleFinishRecruiting = useCallback(() => {
-    setIsFinishModalOpen(false);
-    Toast.show({
-      type: "default",
-      text1: "독서메이트 모집을 성공적으로 마감했어요.",
-    });
-  }, []);
+    if (!recruitingRoomDetailData || isPendingCloseRoomRecruiting) return;
+    closeRoomRecruiting(
+      { roomId: recruitingRoomDetailData.roomId },
+      {
+        onSettled: () => {
+          setIsFinishModalOpen(false);
+        },
+      },
+    );
+  }, [
+    closeRoomRecruiting,
+    recruitingRoomDetailData,
+    isPendingCloseRoomRecruiting,
+  ]);
 
   const handleClosePassword = useCallback(() => {
     setIsPasswordOpen(false);
@@ -159,7 +193,7 @@ export default function JoinGroupScreen() {
           <AppText weight="semibold" size="lg" color={colors.white}>
             데이터를 불러오지 못했어요.{" "}
             {recruitingRoomDetailError?.code
-              ? `${recruitingRoomDetailError.code}`
+              ? `(${recruitingRoomDetailError.code})`
               : "다시 시도해 주세요."}
           </AppText>
         </View>

--- a/src/apis/room/room.queries.ts
+++ b/src/apis/room/room.queries.ts
@@ -310,11 +310,15 @@ export const useCloseRoomRecruitingMutation = () => {
     CloseRoomRecruitingRequest
   >({
     mutationFn: closeRoomRecruitingApi,
-    onSuccess: () => {
+    onSuccess: (data) => {
       queryClient.invalidateQueries({ queryKey: ROOM_QUERY_KEY.ALL });
       Toast.show({
         type: "default",
         text1: "독서메이트 모집을 성공적으로 마감했어요.",
+      });
+      router.replace({
+        pathname: "/group-detail/[roomId]",
+        params: { roomId: data.roomId },
       });
     },
     onError: (error) => {
@@ -331,6 +335,7 @@ export const useCloseRoomRecruitingMutation = () => {
   };
 };
 
+// TODO: 화면에 연동 필요
 export const useLeaveRoomMutation = () => {
   const queryClient = useQueryClient();
   const { mutate: leaveRoom, isPending: isPendingLeaveRoom } = useMutation<
@@ -360,6 +365,7 @@ export const useLeaveRoomMutation = () => {
   };
 };
 
+// TODO: 화면에 연동 필요
 export const useVerifyPrivateRoomPassword = () => {
   const {
     mutate: verifyPrivateRoomPassword,

--- a/src/apis/room/room.queries.ts
+++ b/src/apis/room/room.queries.ts
@@ -335,7 +335,6 @@ export const useCloseRoomRecruitingMutation = () => {
   };
 };
 
-// TODO: 화면에 연동 필요
 export const useLeaveRoomMutation = () => {
   const queryClient = useQueryClient();
   const { mutate: leaveRoom, isPending: isPendingLeaveRoom } = useMutation<
@@ -365,7 +364,6 @@ export const useLeaveRoomMutation = () => {
   };
 };
 
-// TODO: 화면에 연동 필요
 export const useVerifyPrivateRoomPassword = () => {
   const {
     mutate: verifyPrivateRoomPassword,
@@ -376,12 +374,6 @@ export const useVerifyPrivateRoomPassword = () => {
     VerifyPrivateRoomPasswordRequest
   >({
     mutationFn: verifyPrivateRoomPasswordApi,
-    // TODO: 이부분은 추후 페이지에서 사용할 때, onSuccess 하기
-    onSuccess: (data) => {
-      if (data.matched) {
-      } else {
-      }
-    },
     onError: (error) => {
       Toast.show({
         type: "error",


### PR DESCRIPTION
## 📌 Related Issues

- close #145 

## 📄 Tasks

- 모집 중인 모임방의 참여 및 참여 취소 API를 연동했습니다.
  - 공개방은 참여 버튼을 누르면 바로 참여 요청을 보냅니다.
  - 참여 중인 방은 확인 모달을 거쳐 참여를 취소합니다.
  - API 요청 중 중복 요청이 발생하지 않도록 처리했습니다.

- 비공개 모임방 참여 흐름을 연동했습니다.
  - 비밀번호 4자리 입력 시 검증 API를 호출합니다.
  - 비밀번호가 일치하면 모임방 참여 API를 호출합니다.
  - 비밀번호가 일치하지 않으면 입력창과 안내 문구로 오류를 표시합니다.
  - 기존 더미 비밀번호를 제거했습니다.

- 방장의 모집 마감 API를 연동했습니다.
  - 성공 시 관련 모임방 쿼리 캐시를 갱신합니다.
  - 모집 마감 후 진행 중인 모임방 상세 화면으로 이동합니다.

- 모임방 상세 화면의 모임 나가기 API를 연동했습니다.

- 각 API 요청의 성공 및 실패 결과를 토스트로 안내합니다.

- 모집방 상세 조회 오류 코드의 표시 형식을 개선했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 모임 참여 비밀번호를 서버에서 검증하도록 개선했습니다.
  * 참여/참여 취소/모집 마감 흐름이 서버 요청을 기준으로 동작합니다.
* **버그 수정**
  * 모임 퇴장 요청의 중복 실행을 방지했습니다.
  * 비밀번호 검증 결과에 따라 오류 표시와 진행 흐름이 정확히 반영됩니다.
  * 모집 마감 처리 후 모임 화면으로 자동 이동/모달 처리 흐름을 정리했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->