### PR TITLE
[Feature/#138] 애플 로그인 기능 구현 및 api 연동 / 알림 권한 관련 기능 리팩토링

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -92,6 +92,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     ...config.ios,
     bundleIdentifier: "com.texthip.thip",
     googleServicesFile: googleServiceInfoPlist,
+    usesAppleSignIn: true,
   },
   android: {
     ...appJson.expo.android,

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-prettier": "^5.5.4",
         "expo": "~54.0.36",
+        "expo-apple-authentication": "~8.0.8",
         "expo-asset": "~12.0.13",
         "expo-blur": "~15.0.8",
         "expo-build-properties": "~1.0.10",
@@ -7656,6 +7657,16 @@
         "react-native-webview": {
           "optional": true
         }
+      }
+    },
+    "node_modules/expo-apple-authentication": {
+      "version": "8.0.8",
+      "resolved": "https://registry.npmjs.org/expo-apple-authentication/-/expo-apple-authentication-8.0.8.tgz",
+      "integrity": "sha512-TwCHWXYR1kS0zaeV7QZKLWYluxsvqL31LFJubzK30njZqeWoWO89HZ8nZVaeXbFV1LrArKsze4BmMb+94wS0AQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react-native": "*"
       }
     },
     "node_modules/expo-application": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.4",
     "expo": "~54.0.36",
+    "expo-apple-authentication": "~8.0.8",
     "expo-asset": "~12.0.13",
     "expo-blur": "~15.0.8",
     "expo-build-properties": "~1.0.10",

--- a/screens/(user)/alarm-settings/alarm-settings-screen.tsx
+++ b/screens/(user)/alarm-settings/alarm-settings-screen.tsx
@@ -1,29 +1,165 @@
-import { StyleSheet, View } from "react-native";
+import * as Notifications from "expo-notifications";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Alert, AppState, Linking, StyleSheet, View } from "react-native";
+import Toast from "react-native-toast-message";
 
 import {
   useChangePushNotificationState,
   useGetPushNotificationState,
+  useRegisterNotificationToken,
 } from "@apis/notification";
+import {
+  isNotificationPermissionGranted,
+  requestNotificationPermission,
+  tryRegisterCurrentDeviceNotificationToken,
+} from "@apis/notification-token";
 import { AppText, CustomSwitch } from "@shared/ui";
 import { colors } from "@theme/token";
 
+const showNotificationPermissionSettingsAlert = () => {
+  Alert.alert(
+    "알림 권한이 꺼져 있어요",
+    "푸시 알림을 받으려면 앱 설정에서 알림 권한을 허용해 주세요.",
+    [
+      { text: "취소", style: "cancel" },
+      {
+        text: "설정으로 이동",
+        onPress: () => {
+          void Linking.openSettings().catch((error) => {
+            console.error("[notification] open settings failed", error);
+            Toast.show({
+              type: "error",
+              text1: "앱 설정을 열지 못했어요.",
+            });
+          });
+        },
+      },
+    ],
+  );
+};
+
 export default function AlarmSettingsScreen() {
-  const {
-    isPushNotificationEnabled,
-    isPendingPushNotificationData,
-    isErrorPushNotificationData,
-  } = useGetPushNotificationState();
+  const isHandlingPermissionRef = useRef(false);
+  const shouldPrepareNotificationAgainRef = useRef(false);
+  const [canRequestNotificationServer, setCanRequestNotificationServer] =
+    useState(false);
+  const { registerNotificationTokenAsync } = useRegisterNotificationToken();
+
+  const { isPushNotificationEnabled, isPendingPushNotificationData } =
+    useGetPushNotificationState(canRequestNotificationServer);
   const { changePushNotification, isPendingChangePushNotification } =
     useChangePushNotificationState();
 
-  const handleToggleSwitch = () => {
+  const prepareNotificationServer = useCallback(async () => {
+    if (isHandlingPermissionRef.current) {
+      shouldPrepareNotificationAgainRef.current = true;
+      return;
+    }
+
+    isHandlingPermissionRef.current = true;
+
+    try {
+      do {
+        shouldPrepareNotificationAgainRef.current = false;
+        setCanRequestNotificationServer(false);
+
+        const hasPermission = isNotificationPermissionGranted(
+          await Notifications.getPermissionsAsync(),
+        );
+
+        if (!hasPermission) {
+          continue;
+        }
+
+        const isTokenRegistered =
+          await tryRegisterCurrentDeviceNotificationToken(
+            registerNotificationTokenAsync,
+          );
+
+        if (!shouldPrepareNotificationAgainRef.current) {
+          setCanRequestNotificationServer(isTokenRegistered);
+        }
+      } while (shouldPrepareNotificationAgainRef.current);
+    } catch (error) {
+      console.error(
+        "[AlarmSettingsScreen] notification preparation failed",
+        error,
+      );
+      setCanRequestNotificationServer(false);
+    } finally {
+      isHandlingPermissionRef.current = false;
+    }
+  }, [registerNotificationTokenAsync]);
+
+  useEffect(() => {
+    void prepareNotificationServer();
+
+    const subscription = AppState.addEventListener("change", (nextState) => {
+      if (nextState === "active") {
+        void prepareNotificationServer();
+      }
+    });
+
+    return () => {
+      subscription.remove();
+    };
+  }, [prepareNotificationServer]);
+
+  const handleToggleSwitch = async () => {
     if (
       isPendingChangePushNotification ||
       isPendingPushNotificationData ||
-      isErrorPushNotificationData
+      isHandlingPermissionRef.current
     )
-      return null;
-    changePushNotification({ enable: !isPushNotificationEnabled });
+      return;
+
+    isHandlingPermissionRef.current = true;
+    setCanRequestNotificationServer(false);
+
+    try {
+      const hasPermission = await requestNotificationPermission();
+
+      if (!hasPermission) {
+        showNotificationPermissionSettingsAlert();
+        return;
+      }
+
+      if (isPushNotificationEnabled) {
+        setCanRequestNotificationServer(true);
+        changePushNotification({ enable: false });
+        return;
+      }
+
+      const isTokenRegistered = await tryRegisterCurrentDeviceNotificationToken(
+        registerNotificationTokenAsync,
+      );
+      setCanRequestNotificationServer(isTokenRegistered);
+
+      if (!isTokenRegistered) {
+        Toast.show({
+          type: "error",
+          text1: "푸시 알림 설정에 실패했어요. 다시 시도해 주세요.",
+        });
+        return;
+      }
+
+      changePushNotification({ enable: true });
+    } catch (error) {
+      console.error(
+        "[AlarmSettingsScreen] notification permission failed",
+        error,
+      );
+      Toast.show({
+        type: "error",
+        text1: "알림 권한을 확인하지 못했어요. 다시 시도해 주세요.",
+      });
+    } finally {
+      isHandlingPermissionRef.current = false;
+
+      if (shouldPrepareNotificationAgainRef.current) {
+        void prepareNotificationServer();
+      }
+    }
   };
 
   return (

--- a/screens/(user)/alarm-settings/alarm-settings-screen.tsx
+++ b/screens/(user)/alarm-settings/alarm-settings-screen.tsx
@@ -1,6 +1,4 @@
-import * as Notifications from "expo-notifications";
-import { useCallback, useEffect, useRef, useState } from "react";
-import { Alert, AppState, Linking, StyleSheet, View } from "react-native";
+import { Alert, Linking, StyleSheet, View } from "react-native";
 import Toast from "react-native-toast-message";
 
 import {
@@ -9,7 +7,6 @@ import {
   useRegisterNotificationToken,
 } from "@apis/notification";
 import {
-  isNotificationPermissionGranted,
   requestNotificationPermission,
   tryRegisterCurrentDeviceNotificationToken,
 } from "@apis/notification-token";
@@ -39,84 +36,24 @@ const showNotificationPermissionSettingsAlert = () => {
 };
 
 export default function AlarmSettingsScreen() {
-  const isHandlingPermissionRef = useRef(false);
-  const shouldPrepareNotificationAgainRef = useRef(false);
-  const [canRequestNotificationServer, setCanRequestNotificationServer] =
-    useState(false);
   const { registerNotificationTokenAsync } = useRegisterNotificationToken();
 
   const { isPushNotificationEnabled, isPendingPushNotificationData } =
-    useGetPushNotificationState(canRequestNotificationServer);
+    useGetPushNotificationState();
   const { changePushNotification, isPendingChangePushNotification } =
     useChangePushNotificationState();
 
-  const prepareNotificationServer = useCallback(async () => {
-    if (isHandlingPermissionRef.current) {
-      shouldPrepareNotificationAgainRef.current = true;
-      return;
-    }
-
-    isHandlingPermissionRef.current = true;
-
-    try {
-      do {
-        shouldPrepareNotificationAgainRef.current = false;
-        setCanRequestNotificationServer(false);
-
-        const hasPermission = isNotificationPermissionGranted(
-          await Notifications.getPermissionsAsync(),
-        );
-
-        if (!hasPermission) {
-          continue;
-        }
-
-        const isTokenRegistered =
-          await tryRegisterCurrentDeviceNotificationToken(
-            registerNotificationTokenAsync,
-          );
-
-        if (!shouldPrepareNotificationAgainRef.current) {
-          setCanRequestNotificationServer(isTokenRegistered);
-        }
-      } while (shouldPrepareNotificationAgainRef.current);
-    } catch (error) {
-      console.error(
-        "[AlarmSettingsScreen] notification preparation failed",
-        error,
-      );
-      setCanRequestNotificationServer(false);
-    } finally {
-      isHandlingPermissionRef.current = false;
-    }
-  }, [registerNotificationTokenAsync]);
-
-  useEffect(() => {
-    void prepareNotificationServer();
-
-    const subscription = AppState.addEventListener("change", (nextState) => {
-      if (nextState === "active") {
-        void prepareNotificationServer();
-      }
-    });
-
-    return () => {
-      subscription.remove();
-    };
-  }, [prepareNotificationServer]);
-
   const handleToggleSwitch = async () => {
-    if (
-      isPendingChangePushNotification ||
-      isPendingPushNotificationData ||
-      isHandlingPermissionRef.current
-    )
+    if (isPendingChangePushNotification || isPendingPushNotificationData) {
       return;
-
-    isHandlingPermissionRef.current = true;
-    setCanRequestNotificationServer(false);
+    }
 
     try {
+      if (isPushNotificationEnabled) {
+        changePushNotification({ enable: false });
+        return;
+      }
+
       const hasPermission = await requestNotificationPermission();
 
       if (!hasPermission) {
@@ -124,16 +61,9 @@ export default function AlarmSettingsScreen() {
         return;
       }
 
-      if (isPushNotificationEnabled) {
-        setCanRequestNotificationServer(true);
-        changePushNotification({ enable: false });
-        return;
-      }
-
       const isTokenRegistered = await tryRegisterCurrentDeviceNotificationToken(
         registerNotificationTokenAsync,
       );
-      setCanRequestNotificationServer(isTokenRegistered);
 
       if (!isTokenRegistered) {
         Toast.show({
@@ -153,12 +83,6 @@ export default function AlarmSettingsScreen() {
         type: "error",
         text1: "알림 권한을 확인하지 못했어요. 다시 시도해 주세요.",
       });
-    } finally {
-      isHandlingPermissionRef.current = false;
-
-      if (shouldPrepareNotificationAgainRef.current) {
-        void prepareNotificationServer();
-      }
     }
   };
 

--- a/screens/login/components/index.ts
+++ b/screens/login/components/index.ts
@@ -1,1 +1,5 @@
-export { GoogleLoginButton, KakaoLoginButton } from "./login-button";
+export {
+  AppleLoginButton,
+  GoogleLoginButton,
+  KakaoLoginButton,
+} from "./login-button";

--- a/screens/login/components/login-button/apple-login-button.tsx
+++ b/screens/login/components/login-button/apple-login-button.tsx
@@ -1,11 +1,14 @@
 import * as AppleAuthentication from "expo-apple-authentication";
 import { StyleSheet } from "react-native";
+import Toast from "react-native-toast-message";
 
 import { useAppleLoginMutation } from "@apis/auth";
 
 export default function AppleLoginButton() {
   const { appleLogin, isPendingAppleLogin } = useAppleLoginMutation();
   const handleLogin = async () => {
+    if (isPendingAppleLogin) return;
+
     try {
       const credential = await AppleAuthentication.signInAsync({
         requestedScopes: [
@@ -22,16 +25,11 @@ export default function AppleLoginButton() {
         identityToken: credential.identityToken,
         authorizationCode: credential.authorizationCode,
       });
-    } catch (error) {
-      if (
-        error instanceof Error &&
-        "code" in error &&
-        error.code === "ERR_REQUEST_CANCELED"
-      ) {
-        return;
-      }
-
-      console.error("[AppleLoginButton] Apple login failed", error);
+    } catch {
+      Toast.show({
+        type: "error",
+        text1: "애플 로그인에 실패했어요.",
+      });
     }
   };
 
@@ -42,7 +40,6 @@ export default function AppleLoginButton() {
       cornerRadius={12}
       style={styles.loginButtonContainer}
       onPress={handleLogin}
-      aria-disabled={isPendingAppleLogin}
     />
   );
 }

--- a/screens/login/components/login-button/apple-login-button.tsx
+++ b/screens/login/components/login-button/apple-login-button.tsx
@@ -1,0 +1,55 @@
+import * as AppleAuthentication from "expo-apple-authentication";
+import { StyleSheet } from "react-native";
+
+import { useAppleLoginMutation } from "@apis/auth";
+
+export default function AppleLoginButton() {
+  const { appleLogin, isPendingAppleLogin } = useAppleLoginMutation();
+  const handleLogin = async () => {
+    try {
+      const credential = await AppleAuthentication.signInAsync({
+        requestedScopes: [
+          AppleAuthentication.AppleAuthenticationScope.FULL_NAME,
+          AppleAuthentication.AppleAuthenticationScope.EMAIL,
+        ],
+      });
+
+      if (!credential.identityToken || !credential.authorizationCode) {
+        throw new Error("Apple 인증 정보를 받지 못했습니다.");
+      }
+
+      appleLogin({
+        identityToken: credential.identityToken,
+        authorizationCode: credential.authorizationCode,
+      });
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        "code" in error &&
+        error.code === "ERR_REQUEST_CANCELED"
+      ) {
+        return;
+      }
+
+      console.error("[AppleLoginButton] Apple login failed", error);
+    }
+  };
+
+  return (
+    <AppleAuthentication.AppleAuthenticationButton
+      buttonType={AppleAuthentication.AppleAuthenticationButtonType.SIGN_IN}
+      buttonStyle={AppleAuthentication.AppleAuthenticationButtonStyle.WHITE}
+      cornerRadius={12}
+      style={styles.loginButtonContainer}
+      onPress={handleLogin}
+      aria-disabled={isPendingAppleLogin}
+    />
+  );
+}
+
+const styles = StyleSheet.create({
+  loginButtonContainer: {
+    width: "100%",
+    height: 44,
+  },
+});

--- a/screens/login/components/login-button/apple-login-button.tsx
+++ b/screens/login/components/login-button/apple-login-button.tsx
@@ -25,7 +25,14 @@ export default function AppleLoginButton() {
         identityToken: credential.identityToken,
         authorizationCode: credential.authorizationCode,
       });
-    } catch {
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        "code" in error &&
+        error.code === "ERR_REQUEST_CANCELED"
+      )
+        return;
+
       Toast.show({
         type: "error",
         text1: "애플 로그인에 실패했어요.",

--- a/screens/login/components/login-button/google-login-button.tsx
+++ b/screens/login/components/login-button/google-login-button.tsx
@@ -27,7 +27,13 @@ export default function GoogleLoginButton() {
       }
 
       login({ oauth2Id: `google_${response.data.user.id}` });
-    } catch {
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        "code" in error &&
+        error.code === "ERR_REQUEST_CANCELED"
+      )
+        return;
       Toast.show({
         type: "error",
         text1: "구글 로그인에 실패했어요.",

--- a/screens/login/components/login-button/index.ts
+++ b/screens/login/components/login-button/index.ts
@@ -1,2 +1,3 @@
+export { default as AppleLoginButton } from "./apple-login-button";
 export { default as GoogleLoginButton } from "./google-login-button";
 export { default as KakaoLoginButton } from "./kakao-login-button";

--- a/screens/login/components/login-button/kakao-login-button.tsx
+++ b/screens/login/components/login-button/kakao-login-button.tsx
@@ -21,7 +21,12 @@ export default function KakaoLoginButton() {
 
       login({ oauth2Id: `kakao_${kakaoUser.id}` });
     } catch (error) {
-      console.error("[KakaoLoginButton] Kakao login failed", error);
+      if (
+        error instanceof Error &&
+        "code" in error &&
+        error.code === "ERR_REQUEST_CANCELED"
+      )
+        return;
 
       Toast.show({
         type: "error",

--- a/screens/login/login-screen.tsx
+++ b/screens/login/login-screen.tsx
@@ -1,10 +1,20 @@
 import { useQueryClient } from "@tanstack/react-query";
 import { useEffect, useRef } from "react";
-import { Image, StyleSheet, useWindowDimensions, View } from "react-native";
+import {
+  Image,
+  Platform,
+  StyleSheet,
+  useWindowDimensions,
+  View,
+} from "react-native";
 
 import { ThipSplash } from "@images/thip";
 
-import { GoogleLoginButton, KakaoLoginButton } from "./components";
+import {
+  AppleLoginButton,
+  GoogleLoginButton,
+  KakaoLoginButton,
+} from "./components";
 
 export default function LoginScreen() {
   const hasClearedRef = useRef(false);
@@ -31,6 +41,7 @@ export default function LoginScreen() {
       <View style={styles.loginButtonWrapper}>
         <KakaoLoginButton />
         <GoogleLoginButton />
+        {Platform.OS === "ios" && <AppleLoginButton />}
       </View>
     </View>
   );

--- a/src/apis/auth/auth.api.ts
+++ b/src/apis/auth/auth.api.ts
@@ -1,11 +1,25 @@
 import { apiClient } from "@apis/api-client";
 import { AUTH_URL } from "@apis/endpoint";
 
-import type { LoginRequest, LoginResponse } from "./auth.types";
+import type {
+  AppleLoginRequest,
+  LoginRequest,
+  LoginResponse,
+} from "./auth.types";
 
 export const loginApi = async (body: LoginRequest) => {
   const response = await apiClient.post<LoginResponse, LoginRequest>(
     AUTH_URL.LOGIN,
+    body,
+    { skipAuth: true },
+  );
+
+  return response.data;
+};
+
+export const appleLoginApi = async (body: AppleLoginRequest) => {
+  const response = await apiClient.post<LoginResponse, AppleLoginRequest>(
+    AUTH_URL.APPLE_LOGIN,
     body,
     { skipAuth: true },
   );

--- a/src/apis/auth/auth.queries.ts
+++ b/src/apis/auth/auth.queries.ts
@@ -12,8 +12,12 @@ import {
   tryRegisterCurrentDeviceNotificationToken,
 } from "../notification-token";
 import { setAuthToken } from "../token-storage";
-import { loginApi } from "./auth.api";
-import type { LoginRequest, LoginResponse } from "./auth.types";
+import { appleLoginApi, loginApi } from "./auth.api";
+import type {
+  AppleLoginRequest,
+  LoginRequest,
+  LoginResponse,
+} from "./auth.types";
 
 export const useLoginMutation = () => {
   const { registerNotificationTokenAsync } = useRegisterNotificationToken();
@@ -51,6 +55,45 @@ export const useLoginMutation = () => {
   return {
     login,
     isPendingLogin, // TODO: 추후 로딩 애니메이션 보여주기
+  };
+};
+
+export const useAppleLoginMutation = () => {
+  const { registerNotificationTokenAsync } = useRegisterNotificationToken();
+
+  const { mutate: appleLogin, isPending: isPendingAppleLogin } = useMutation<
+    LoginResponse,
+    Error,
+    AppleLoginRequest
+  >({
+    mutationFn: appleLoginApi,
+    onSuccess: async (data: LoginResponse) => {
+      await setAuthToken(data.token);
+
+      if (data.isNewUser) {
+        router.replace("/sign-up");
+        return;
+      }
+
+      // fire-and-forget: 등록 실패해도 로그인 플로우에 영향 없음
+      tryRegisterCurrentDeviceNotificationToken(registerNotificationTokenAsync);
+
+      router.replace({
+        pathname: "/",
+      });
+    },
+    onError: (error) => {
+      console.error("[useLoginMutation] login failed", error);
+      Toast.show({
+        type: "error",
+        text1: "로그인에 실패했어요. 잠시 후 다시 시도해주세요.",
+      });
+    },
+  });
+
+  return {
+    appleLogin,
+    isPendingAppleLogin, // TODO: 추후 로딩 애니메이션 보여주기
   };
 };
 

--- a/src/apis/auth/auth.types.ts
+++ b/src/apis/auth/auth.types.ts
@@ -6,3 +6,8 @@ export type LoginResponse = {
   token: string;
   isNewUser: boolean;
 };
+
+export interface AppleLoginRequest {
+  identityToken: string;
+  authorizationCode: string;
+}

--- a/src/apis/auth/index.ts
+++ b/src/apis/auth/index.ts
@@ -1,4 +1,15 @@
-export { loginApi } from "./auth.api";
-export { useLoginMutation, useLogout } from "./auth.queries";
-export type { LoginRequest, LoginResponse } from "./auth.types";
+export { appleLoginApi, loginApi } from "./auth.api";
+
+export {
+  useAppleLoginMutation,
+  useLoginMutation,
+  useLogout,
+} from "./auth.queries";
+
+export type {
+  AppleLoginRequest,
+  LoginRequest,
+  LoginResponse,
+} from "./auth.types";
+
 export { initializeKakao } from "./kakao";

--- a/src/apis/endpoint.ts
+++ b/src/apis/endpoint.ts
@@ -1,5 +1,6 @@
 export const AUTH_URL = {
   LOGIN: "/auth/users",
+  APPLE_LOGIN: "/auth/apple",
 } as const;
 
 export const USER_URL = {

--- a/src/apis/notification-token.ts
+++ b/src/apis/notification-token.ts
@@ -57,7 +57,7 @@ const setAndroidNotificationChannel = async () => {
   );
 };
 
-const isNotificationPermissionGranted = (
+export const isNotificationPermissionGranted = (
   permissions: Notifications.NotificationPermissionsStatus,
 ) => {
   if (permissions.status === "granted") {
@@ -73,11 +73,21 @@ const isNotificationPermissionGranted = (
   );
 };
 
-const requestNotificationPermission = async () => {
+export const requestNotificationPermission = async () => {
   const existingPermissions = await Notifications.getPermissionsAsync();
 
-  if (isNotificationPermissionGranted(existingPermissions)) {
+  const permissionAction = isNotificationPermissionGranted(existingPermissions)
+    ? "granted"
+    : existingPermissions.canAskAgain
+      ? "request"
+      : "settings";
+
+  if (permissionAction === "granted") {
     return true;
+  }
+
+  if (permissionAction === "settings") {
+    return false;
   }
 
   const requestedPermissions = await Notifications.requestPermissionsAsync();

--- a/src/apis/notification-token.ts
+++ b/src/apis/notification-token.ts
@@ -57,7 +57,7 @@ const setAndroidNotificationChannel = async () => {
   );
 };
 
-export const isNotificationPermissionGranted = (
+const isNotificationPermissionGranted = (
   permissions: Notifications.NotificationPermissionsStatus,
 ) => {
   if (permissions.status === "granted") {

--- a/src/apis/notification/notification.queries.ts
+++ b/src/apis/notification/notification.queries.ts
@@ -225,7 +225,7 @@ export const useCheckNotification = () => {
   };
 };
 
-export const useGetPushNotificationState = (enabled = true) => {
+export const useGetPushNotificationState = () => {
   const {
     data,
     isFetching: isPendingPushNotificationData,
@@ -234,25 +234,23 @@ export const useGetPushNotificationState = (enabled = true) => {
   } = useQuery<GetPushNotificationStateResponse, Error>({
     queryKey: NOTIFICATION_QUERY_KEY.NOTIFICATION_STATE,
     queryFn: getPushNotificationStateApi,
-    enabled,
   });
 
   useEffect(() => {
-    if (!enabled || !isErrorPushNotificationData || !error) return;
+    if (!isErrorPushNotificationData || !error) return;
 
     Toast.show({
       type: "error",
       text1: error.message,
     });
-  }, [enabled, isErrorPushNotificationData, error]);
+  }, [isErrorPushNotificationData, error]);
 
-  const isPushNotificationEnabled = enabled && (data?.isEnabled ?? false);
+  const isPushNotificationEnabled = data?.isEnabled ?? false;
 
   return {
     isPushNotificationEnabled,
     isPendingPushNotificationData,
-    isErrorPushNotificationData:
-      enabled && isErrorPushNotificationData,
+    isErrorPushNotificationData: isErrorPushNotificationData,
   };
 };
 

--- a/src/apis/notification/notification.queries.ts
+++ b/src/apis/notification/notification.queries.ts
@@ -225,32 +225,34 @@ export const useCheckNotification = () => {
   };
 };
 
-export const useGetPushNotificationState = () => {
+export const useGetPushNotificationState = (enabled = true) => {
   const {
     data,
-    isPending: isPendingPushNotificationData,
+    isFetching: isPendingPushNotificationData,
     isError: isErrorPushNotificationData,
     error,
   } = useQuery<GetPushNotificationStateResponse, Error>({
     queryKey: NOTIFICATION_QUERY_KEY.NOTIFICATION_STATE,
     queryFn: getPushNotificationStateApi,
+    enabled,
   });
 
   useEffect(() => {
-    if (!isErrorPushNotificationData || !error) return;
+    if (!enabled || !isErrorPushNotificationData || !error) return;
 
     Toast.show({
       type: "error",
       text1: error.message,
     });
-  }, [isErrorPushNotificationData, error]);
+  }, [enabled, isErrorPushNotificationData, error]);
 
-  const isPushNotificationEnabled = data?.isEnabled ?? false;
+  const isPushNotificationEnabled = enabled && (data?.isEnabled ?? false);
 
   return {
     isPushNotificationEnabled,
     isPendingPushNotificationData,
-    isErrorPushNotificationData,
+    isErrorPushNotificationData:
+      enabled && isErrorPushNotificationData,
   };
 };
 


### PR DESCRIPTION
## 📌 Related Issues

- close #138 

## 📄 Tasks

### Apple 로그인 구현

- `expo-apple-authentication` 의존성을 추가했습니다.
- iOS의 Apple 로그인 capability를 활성화했습니다.
- 로그인 화면에서 Apple 로그인 버튼이 iOS에만 노출되도록 처리했습니다.
- Apple 인증 과정에서 `identityToken`, `authorizationCode`를 받아 `/auth/apple` API와 연동했습니다.
- 로그인 성공 이후 기존 로그인과 동일하게 처리했습니다.
  - 인증 토큰 저장
  - 신규 사용자 회원가입 화면 이동
  - 기존 사용자 홈 화면 이동
  - 푸시 알림 토큰 등록
- 사용자가 Apple 로그인을 취소한 경우 별도의 오류로 처리하지 않도록 했습니다.

### 푸시 알림 권한 설정 흐름 개선

- OS 알림 권한과 디바이스 토큰 등록 여부를 확인한 후 서버의 푸시 알림 설정을 조회하도록 변경했습니다.
- 알림 권한을 다시 요청할 수 없는 경우 앱 설정으로 이동할 수 있는 안내창을 표시합니다.
- 앱 설정에서 알림 권한을 변경하고 앱으로 돌아오면 권한과 토큰 등록 상태를 다시 확인합니다.
- 푸시 알림 활성화 전에 현재 디바이스의 알림 토큰이 정상적으로 등록되도록 처리했습니다.
- 권한 확인이나 토큰 등록에 실패한 경우 Toast를 통해 사용자에게 안내합니다.
- 권한 확인과 토큰 등록 요청이 중복으로 실행되지 않도록 동시 실행을 방지했습니다.
- 알림 권한과 디바이스 토큰이 준비되기 전에는 서버의 푸시 알림 설정 조회가 실행되지 않도록 쿼리 조건을 추가했습니다.

## ⭐ PR Point (To Reviewer)

- Apple 로그인에서 전달하는 `identityToken`, `authorizationCode`가 백엔드 API 규격과 일치하는지 확인 부탁드립니다.
- Apple 로그인 성공 후 신규 사용자와 기존 사용자의 화면 이동 흐름을 확인 부탁드립니다.
- 앱 설정에서 알림 권한을 변경한 뒤 앱으로 복귀했을 때 권한 확인, 토큰 등록, 서버 설정 조회가 순서대로 동작하는지 확인 부탁드립니다.
- 알림 권한 확인과 토큰 등록 중복 실행을 방지하기 위한 상태 처리 로직을 중점적으로 확인 부탁드립니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새 기능**
  - iOS에서 Apple 로그인 버튼이 추가되었습니다.
  - Apple 로그인: 신규 사용자는 회원가입으로, 기존 사용자는 홈 화면으로 이동합니다.
  - Apple 로그인 및 푸시 알림 관련 iOS 설정이 반영되었습니다.

- **개선 사항**
  - 푸시 알림 토글이 권한 확인 → 필요 시 알림 권한/기기 토큰 등록 → 활성화 흐름으로 변경되었습니다.
  - 알림 권한이 없을 때는 앱 설정 화면으로 유도됩니다.
  - 푸시 알림 상태 로딩 표시가 더 정확해졌습니다.
  - 로그인 중 요청 취소(취소됨) 예외 처리가 조용히 처리되도록 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->