### PR TITLE
[Feature/#155] 투표하기 및 모임방 좋아요 api 연동, 댓글 api 연동

### DIFF
--- a/screens/create-vote/create-vote-screen.tsx
+++ b/screens/create-vote/create-vote-screen.tsx
@@ -123,8 +123,6 @@ export default function CreateVoteScreen() {
     }
   }, [isErrorBookPageInfo, bookPageInfoError?.message]);
 
-  if (!roomId || isErrorBookPageInfo || !bookPageInfo) return null;
-
   if (isPendingBookPageInfo) {
     return (
       <View style={styles.status}>
@@ -132,6 +130,8 @@ export default function CreateVoteScreen() {
       </View>
     );
   }
+
+  if (!roomId || isErrorBookPageInfo || !bookPageInfo) return null;
 
   return (
     <View style={styles.page}>

--- a/screens/create-vote/create-vote-screen.tsx
+++ b/screens/create-vote/create-vote-screen.tsx
@@ -101,15 +101,29 @@ export default function CreateVoteScreen() {
     isPendingCreateRoomVote ||
     isPendingEditRoomVote;
 
-  if (!roomId) {
-    Toast.show({
-      type: "error",
-      text1: "잘못된 접근이에요. 다시 시도해 주세요.",
-    });
-    router.back();
+  useEffect(() => {
+    if (!roomId) {
+      Toast.show({
+        type: "error",
+        text1: "잘못된 접근이에요. 다시 시도해 주세요.",
+      });
 
-    return;
-  }
+      router.back();
+    }
+  }, [roomId]);
+
+  useEffect(() => {
+    if (isErrorBookPageInfo) {
+      Toast.show({
+        type: "error",
+        text1: bookPageInfoError?.message,
+      });
+
+      router.back();
+    }
+  }, [isErrorBookPageInfo, bookPageInfoError?.message]);
+
+  if (!roomId || isErrorBookPageInfo || !bookPageInfo) return null;
 
   if (isPendingBookPageInfo) {
     return (
@@ -117,16 +131,6 @@ export default function CreateVoteScreen() {
         <ActivityIndicator size="large" color={colors.white} />
       </View>
     );
-  }
-
-  if (isErrorBookPageInfo || !bookPageInfo) {
-    Toast.show({
-      type: "error",
-      text1: bookPageInfoError?.message,
-    });
-    router.back();
-
-    return;
   }
 
   return (

--- a/screens/daily-greeting/daily-greeting-screen.tsx
+++ b/screens/daily-greeting/daily-greeting-screen.tsx
@@ -60,6 +60,8 @@ export default function DailyGreetingScreen() {
     }
   }, [roomId]);
 
+  if (!roomId) return null;
+
   const StatusView = () => {
     if (isPendingDailyGreeting)
       return (

--- a/screens/daily-greeting/daily-greeting-screen.tsx
+++ b/screens/daily-greeting/daily-greeting-screen.tsx
@@ -1,5 +1,5 @@
 import { router, useLocalSearchParams } from "expo-router";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { ActivityIndicator, FlatList, StyleSheet, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import Toast from "react-native-toast-message";
@@ -49,15 +49,16 @@ export default function DailyGreetingScreen() {
     fetchNextPage();
   };
 
-  if (!roomId) {
-    Toast.show({
-      type: "error",
-      text1: "잘못된 접근이에요. 다시 시도해 주세요.",
-    });
-    router.back();
+  useEffect(() => {
+    if (!roomId) {
+      Toast.show({
+        type: "error",
+        text1: "잘못된 접근이에요. 다시 시도해 주세요.",
+      });
 
-    return;
-  }
+      router.back();
+    }
+  }, [roomId]);
 
   const StatusView = () => {
     if (isPendingDailyGreeting)

--- a/screens/feed-detail/feed-detail-screen.tsx
+++ b/screens/feed-detail/feed-detail-screen.tsx
@@ -43,6 +43,7 @@ export default function FeedDetailScreen() {
     isFetchingNextPage,
     isPendingCommentList,
     isErrorCommentList,
+    commentListError,
     refetchCommentList,
     isRefetchingCommentList,
   } = useGetCommentListQuery(feedId, "FEED");
@@ -160,7 +161,7 @@ export default function FeedDetailScreen() {
       return (
         <View style={styles.empty}>
           <AppText weight="medium" size="sm" color={colors.grey[200]}>
-            댓글을 불러오지 못했어요.
+            댓글을 불러오지 못했어요. ({commentListError?.message})
           </AppText>
         </View>
       );

--- a/screens/my-page/constants/index.ts
+++ b/screens/my-page/constants/index.ts
@@ -44,5 +44,5 @@ export const SETTINGS_OTHER: SettingsItem[] = [
     icon: IcDocument,
   },
   { id: SETTINGS_ID.guide, label: "가이드", icon: IcGuide },
-  { id: SETTINGS_ID.version, label: "버전 1.0.0", icon: IcVersion },
+  { id: SETTINGS_ID.version, label: "버전 1.3.0", icon: IcVersion },
 ];

--- a/screens/record-book/components/record-book-post-item/index.tsx
+++ b/screens/record-book/components/record-book-post-item/index.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { Image, Pressable, StyleSheet, View } from "react-native";
 import Toast from "react-native-toast-message";
 
+import { type RoomPostType } from "@apis/room";
 import {
   useChangeRoomPostLikeStatusMutation,
   useDeleteRoomPostMutation,
@@ -23,10 +24,9 @@ import RecordVoteList from "./record-vote-list";
 interface RecordBookPostItemProps {
   roomId: number;
   post: RoomPostContent;
-  handleOpenComment: (postId: number) => void;
+  handleOpenComment: (postId: number, postType: RoomPostType) => void;
 }
 
-// TODO: 서버 연결하면서 이벤트 핸들러 구현
 export default function RecordBookPostItem({
   roomId,
   post,

--- a/screens/record-book/components/record-book-post-item/index.tsx
+++ b/screens/record-book/components/record-book-post-item/index.tsx
@@ -5,6 +5,7 @@ import { Image, Pressable, StyleSheet, View } from "react-native";
 import Toast from "react-native-toast-message";
 
 import {
+  useChangeRoomPostLikeStatusMutation,
   useDeleteRoomPostMutation,
   useDoRoomVoteMutation,
   useGetBookInfoForPinQuery,
@@ -56,6 +57,8 @@ export default function RecordBookPostItem({
     isPendingDeleteRoomVote,
   } = useDeleteRoomPostMutation();
   const { doVote, isPendingDoVote } = useDoRoomVoteMutation();
+  const { changeRoomPostLikeStatus, isPendingChangeRoomPostLikeStatus } =
+    useChangeRoomPostLikeStatusMutation(roomId);
 
   const handleToProfile = () => {
     router.push({
@@ -69,8 +72,14 @@ export default function RecordBookPostItem({
     doVote({ roomId, voteId: post.postId, voteItemId, type: !isVoted });
   };
 
-  const handlePressLike = () => {
-    console.log(post.postId, "번 기록 좋아요 클릭");
+  const handlePressLike = (isLiked: boolean) => {
+    if (isPendingChangeRoomPostLikeStatus) return;
+
+    changeRoomPostLikeStatus({
+      postId: post.postId,
+      type: !isLiked,
+      roomPostType: post.postType,
+    });
   };
 
   const handleOpenOption = () => {

--- a/screens/record-book/components/record-book-post-item/index.tsx
+++ b/screens/record-book/components/record-book-post-item/index.tsx
@@ -6,6 +6,7 @@ import Toast from "react-native-toast-message";
 
 import {
   useDeleteRoomPostMutation,
+  useDoRoomVoteMutation,
   useGetBookInfoForPinQuery,
   type RoomPostContent,
 } from "@apis/room-post";
@@ -54,6 +55,7 @@ export default function RecordBookPostItem({
     isPendingDeleteRoomRecord,
     isPendingDeleteRoomVote,
   } = useDeleteRoomPostMutation();
+  const { doVote, isPendingDoVote } = useDoRoomVoteMutation();
 
   const handleToProfile = () => {
     router.push({
@@ -62,8 +64,9 @@ export default function RecordBookPostItem({
     });
   };
 
-  const handleVote = (voteItemId: number) => {
-    console.log(roomId, "번 방 ", voteItemId, "번 투표");
+  const handleVote = (voteItemId: number, isVoted: boolean) => {
+    if (isPendingDoVote) return;
+    doVote({ roomId, voteId: post.postId, voteItemId, type: !isVoted });
   };
 
   const handlePressLike = () => {

--- a/screens/record-book/components/record-book-post-item/record-post-actions.tsx
+++ b/screens/record-book/components/record-book-post-item/record-post-actions.tsx
@@ -17,7 +17,7 @@ interface RecordPostActionsProps {
   postType: RoomPostType;
   likeCount: number;
   commentCount: number;
-  handlePressLike: () => void;
+  handlePressLike: (isLiked: boolean) => void;
   handleOpenComment: (postId: number) => void;
   handleOpenPinModal: () => void;
 }
@@ -37,7 +37,7 @@ export default function RecordPostActions({
     <View style={styles.container}>
       <Pressable
         style={styles.likeComment}
-        onPress={handlePressLike}
+        onPress={() => handlePressLike(isLiked)}
         hitSlop={5}
       >
         {isLiked ? <IcHeartLeftFilled /> : <IcHeartLeft />}

--- a/screens/record-book/components/record-book-post-item/record-post-actions.tsx
+++ b/screens/record-book/components/record-book-post-item/record-post-actions.tsx
@@ -18,7 +18,7 @@ interface RecordPostActionsProps {
   likeCount: number;
   commentCount: number;
   handlePressLike: (isLiked: boolean) => void;
-  handleOpenComment: (postId: number) => void;
+  handleOpenComment: (postId: number, postType: RoomPostType) => void;
   handleOpenPinModal: () => void;
 }
 
@@ -47,7 +47,7 @@ export default function RecordPostActions({
       </Pressable>
       <Pressable
         style={styles.likeComment}
-        onPress={() => handleOpenComment(postId)}
+        onPress={() => handleOpenComment(postId, postType)}
         hitSlop={5}
       >
         <IcComment />

--- a/screens/record-book/components/record-book-post-item/record-vote-list.tsx
+++ b/screens/record-book/components/record-book-post-item/record-vote-list.tsx
@@ -8,7 +8,7 @@ import { calculateVoteFillPercent } from "../../utils";
 
 interface RecordVoteListProps {
   voteItems: RoomPostVote[];
-  handleVote: (voteItemId: number) => void;
+  handleVote: (voteItemId: number, isVoted: boolean) => void;
 }
 
 export default function RecordVoteList({
@@ -33,7 +33,7 @@ export default function RecordVoteList({
           <Pressable
             key={item.voteItemId}
             style={[styles.voteItem, item.isVoted && styles.isVotedItem]}
-            onPress={() => handleVote(item.voteItemId)}
+            onPress={() => handleVote(item.voteItemId, item.isVoted)}
           >
             <AppText
               style={styles.voteContent}

--- a/screens/record-book/components/record-comment-bottom-sheet/index.tsx
+++ b/screens/record-book/components/record-comment-bottom-sheet/index.tsx
@@ -53,8 +53,6 @@ export default function RecordCommentBottomSheet({
     isPendingCommentList,
     isErrorCommentList,
     commentListError,
-    refetchCommentList,
-    isRefetchingCommentList,
   } = useGetCommentListQuery(postId, postType);
   const { writeComment, isPendingWriteComment } = useWriteCommentMutation();
 
@@ -107,10 +105,6 @@ export default function RecordCommentBottomSheet({
       sheetRef.current?.snapToIndex(1);
     }
   }, [isInputFocus]);
-
-  useEffect(() => {
-    refetchCommentList();
-  }, [refetchCommentList]);
 
   return (
     isVisible && (
@@ -170,7 +164,7 @@ export default function RecordCommentBottomSheet({
               />
             )}
             ListEmptyComponent={() =>
-              isPendingCommentList || isRefetchingCommentList ? (
+              isPendingCommentList ? (
                 <View style={styles.status}>
                   <ActivityIndicator size="large" color={colors.white} />
                 </View>
@@ -204,11 +198,7 @@ export default function RecordCommentBottomSheet({
           handleResetReply={handleResetReply}
           isFocus={isInputFocus}
           handleIsFocus={setIsInputFocus}
-          isPendingSend={
-            isPendingCommentList ||
-            isRefetchingCommentList ||
-            isPendingWriteComment
-          }
+          isPendingSend={isPendingCommentList || isPendingWriteComment}
         />
       </GestureHandlerRootView>
     )

--- a/screens/record-book/components/record-comment-bottom-sheet/index.tsx
+++ b/screens/record-book/components/record-comment-bottom-sheet/index.tsx
@@ -2,28 +2,36 @@ import BottomSheet, {
   BottomSheetBackdrop,
   BottomSheetFlatList,
 } from "@gorhom/bottom-sheet";
+import { useQueryClient } from "@tanstack/react-query";
 import { BlurView } from "expo-blur";
 import { useEffect, useRef, useState } from "react";
-import { Platform, StyleSheet, View } from "react-native";
+import { ActivityIndicator, Platform, StyleSheet, View } from "react-native";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
-import { type CommentType } from "@apis/comment";
+import {
+  useGetCommentListQuery,
+  useWriteCommentMutation,
+  type CommentType,
+} from "@apis/comment";
+import { type RoomPostType } from "@apis/room";
+import { ROOM_POST_QUERY_KEY } from "@apis/room-post";
 import { useKeyboardHeight } from "@shared/hooks";
 import { AppText, ChatInputBar, CommentRoot } from "@shared/ui";
 import { colors } from "@theme/token";
 
-import { DUMMY_RECORD_COMMENT_LIST } from "../../constants";
-
 interface RecordCommentBottomSheetProps {
+  roomId: number | string;
   postId: number;
+  postType: RoomPostType;
   isVisible: boolean;
   handleClose: () => void;
 }
 
 export default function RecordCommentBottomSheet({
-  // TODO: 서버 api 연동 시 postId로 댓글 목록 조회/전송
+  roomId,
   postId,
+  postType,
   isVisible,
   handleClose,
 }: RecordCommentBottomSheetProps) {
@@ -36,24 +44,51 @@ export default function RecordCommentBottomSheet({
   const [isInputFocus, setIsInputFocus] = useState(false);
   const keyboardHeight = useKeyboardHeight();
 
+  const queryClient = useQueryClient();
+  const {
+    commentList,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    isPendingCommentList,
+    isErrorCommentList,
+    commentListError,
+    refetchCommentList,
+    isRefetchingCommentList,
+  } = useGetCommentListQuery(postId, postType);
+  const { writeComment, isPendingWriteComment } = useWriteCommentMutation();
+
+  const handleLoadMoreComments = () => {
+    if (!hasNextPage || isFetchingNextPage) return;
+
+    fetchNextPage();
+  };
+
   const listPaddingBottom =
     (replyNickname !== "" ? 30 : 0) +
     (isInputFocus ? keyboardHeight + bottom : bottom);
 
   const handleSendText = () => {
-    if (replyCommentId !== null) {
-      console.log(
-        replyNickname,
-        "에게 ",
-        replyCommentId,
-        "번에 대한 답글 ",
-        comment.trim(),
-        " 전송",
-      );
-    } else {
-      console.log(comment.trim(), " 전송");
-    }
-    setComment("");
+    const content = comment.trim();
+
+    writeComment(
+      {
+        postId,
+        content,
+        isReplyRequest: replyCommentId !== null,
+        parentId: replyCommentId,
+        postType,
+      },
+      {
+        onSuccess: () => {
+          setComment("");
+          handleResetReply();
+          queryClient.invalidateQueries({
+            queryKey: ROOM_POST_QUERY_KEY.ALL_POST(roomId),
+          });
+        },
+      },
+    );
   };
 
   const handlePressReply = (commentId: number, replyNickname: string) => {
@@ -72,6 +107,10 @@ export default function RecordCommentBottomSheet({
       sheetRef.current?.snapToIndex(1);
     }
   }, [isInputFocus]);
+
+  useEffect(() => {
+    refetchCommentList();
+  }, [refetchCommentList]);
 
   return (
     isVisible && (
@@ -120,7 +159,7 @@ export default function RecordCommentBottomSheet({
                   listPaddingBottom + (Platform.OS === "ios" ? 80 : 90),
               },
             ]}
-            data={DUMMY_RECORD_COMMENT_LIST}
+            data={commentList}
             keyExtractor={(item: CommentType) => String(item.commentId)}
             renderItem={({ item }: { item: CommentType }) => (
               <CommentRoot
@@ -130,16 +169,30 @@ export default function RecordCommentBottomSheet({
                 handlePressReply={handlePressReply}
               />
             )}
-            ListEmptyComponent={() => (
-              <View style={styles.empty}>
-                <AppText weight="semibold" size="lg" color={colors.white}>
-                  아직 댓글이 없어요
-                </AppText>
-                <AppText weight="regular" size="sm" color={colors.grey[100]}>
-                  첫번째 댓글을 남겨보세요
-                </AppText>
-              </View>
-            )}
+            ListEmptyComponent={() =>
+              isPendingCommentList || isRefetchingCommentList ? (
+                <View style={styles.status}>
+                  <ActivityIndicator size="large" color={colors.white} />
+                </View>
+              ) : isErrorCommentList ? (
+                <View style={styles.status}>
+                  <AppText weight="semibold" size="lg" color={colors.white}>
+                    댓글을 불러오지 못했어요. ({commentListError?.message})
+                  </AppText>
+                </View>
+              ) : (
+                <View style={styles.status}>
+                  <AppText weight="semibold" size="lg" color={colors.white}>
+                    아직 댓글이 없어요
+                  </AppText>
+                  <AppText weight="regular" size="sm" color={colors.grey[100]}>
+                    첫번째 댓글을 남겨보세요
+                  </AppText>
+                </View>
+              )
+            }
+            onEndReached={handleLoadMoreComments}
+            onEndReachedThreshold={0.5}
           />
         </BottomSheet>
         <ChatInputBar
@@ -151,8 +204,11 @@ export default function RecordCommentBottomSheet({
           handleResetReply={handleResetReply}
           isFocus={isInputFocus}
           handleIsFocus={setIsInputFocus}
-          // TODO: 추후 반영
-          isPendingSend={false}
+          isPendingSend={
+            isPendingCommentList ||
+            isRefetchingCommentList ||
+            isPendingWriteComment
+          }
         />
       </GestureHandlerRootView>
     )
@@ -176,13 +232,14 @@ const styles = StyleSheet.create({
     backgroundColor: "rgba(18, 18, 18, 0.30)",
   },
   list: {
+    minHeight: 300,
     gap: 12,
   },
   title: {
     paddingHorizontal: 20,
     marginBottom: 15,
   },
-  empty: {
+  status: {
     flex: 1,
     gap: 8,
     minHeight: 300,

--- a/screens/record-book/record-book-screen.tsx
+++ b/screens/record-book/record-book-screen.tsx
@@ -1,5 +1,5 @@
 import { router, useLocalSearchParams } from "expo-router";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import {
   ActivityIndicator,
   FlatList,
@@ -173,27 +173,29 @@ export default function RecordBookScreen() {
     setIsCommentOpen(false);
   };
 
-  if (!roomId) {
+  useEffect(() => {
     if (!roomId) {
       Toast.show({
         type: "error",
         text1: "잘못된 접근이에요. 다시 시도해 주세요.",
       });
+
       router.back();
     }
+  }, [roomId]);
 
-    return;
-  }
+  useEffect(() => {
+    if (isErrorBookPageInfo) {
+      Toast.show({
+        type: "error",
+        text1: bookPageInfoError?.message,
+      });
 
-  if (isErrorBookPageInfo || !bookPageInfo) {
-    Toast.show({
-      type: "error",
-      text1: bookPageInfoError?.message,
-    });
-    router.back();
+      router.back();
+    }
+  }, [isErrorBookPageInfo, bookPageInfoError?.message]);
 
-    return;
-  }
+  if (!roomId || isErrorBookPageInfo) return null;
 
   const RecordListHeader = () => {
     if (isMyRecord) return null;

--- a/screens/record-book/record-book-screen.tsx
+++ b/screens/record-book/record-book-screen.tsx
@@ -10,6 +10,7 @@ import {
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import Toast from "react-native-toast-message";
 
+import { type RoomPostType } from "@apis/room";
 import {
   useGetRoomBookPageQuery,
   useGetRoomPostListQuery,
@@ -48,6 +49,8 @@ export default function RecordBookScreen() {
   const [isDropdownVisible, setIsDropdownVisible] = useState(false);
   const [isCommentOpen, setIsCommentOpen] = useState(false);
   const [postIdForComment, setPostIdForComment] = useState<number | null>(null);
+  const [postTypeForComment, setPostTypeForComment] =
+    useState<RoomPostType | null>(null);
 
   const {
     bookPageInfo,
@@ -163,13 +166,15 @@ export default function RecordBookScreen() {
     setIsDropdownVisible(false);
   };
 
-  const handleOpenComment = (postId: number) => {
+  const handleOpenComment = (postId: number, postType: RoomPostType) => {
     setPostIdForComment(postId);
+    setPostTypeForComment(postType);
     setIsCommentOpen(true);
   };
 
   const handleCloseComment = () => {
     setPostIdForComment(null);
+    setPostTypeForComment(null);
     setIsCommentOpen(false);
   };
 
@@ -310,9 +315,11 @@ export default function RecordBookScreen() {
               />
             }
           />
-          {postIdForComment !== null && (
+          {postIdForComment && postTypeForComment && (
             <RecordCommentBottomSheet
+              roomId={roomId}
               postId={postIdForComment}
+              postType={postTypeForComment}
               isVisible={isCommentOpen}
               handleClose={handleCloseComment}
             />

--- a/screens/record-write/record-write-screen.tsx
+++ b/screens/record-write/record-write-screen.tsx
@@ -117,8 +117,6 @@ export default function RecordWriteScreen() {
     }
   }, [isErrorBookPageInfo, bookPageInfoError?.message]);
 
-  if (!roomId || !bookPageInfo) return null;
-
   if (isPendingBookPageInfo) {
     return (
       <View style={styles.status}>
@@ -126,6 +124,8 @@ export default function RecordWriteScreen() {
       </View>
     );
   }
+
+  if (!roomId || !bookPageInfo) return null;
 
   return (
     <View style={styles.page}>

--- a/screens/record-write/record-write-screen.tsx
+++ b/screens/record-write/record-write-screen.tsx
@@ -93,15 +93,31 @@ export default function RecordWriteScreen() {
     isPendingCreateRoomRecord ||
     isPendingEditRoomRecord;
 
-  if (!roomId) {
-    Toast.show({
-      type: "error",
-      text1: "잘못된 접근이에요. 다시 시도해 주세요.",
-    });
-    router.back();
+  useEffect(() => {
+    if (!roomId) {
+      Toast.show({
+        type: "error",
+        text1: "잘못된 접근이에요. 다시 시도해 주세요.",
+      });
+      router.back();
 
-    return;
-  }
+      return;
+    }
+  }, [roomId]);
+
+  useEffect(() => {
+    if (isErrorBookPageInfo) {
+      Toast.show({
+        type: "error",
+        text1: bookPageInfoError?.message,
+      });
+      router.back();
+
+      return;
+    }
+  }, [isErrorBookPageInfo, bookPageInfoError?.message]);
+
+  if (!roomId || !bookPageInfo) return null;
 
   if (isPendingBookPageInfo) {
     return (
@@ -109,16 +125,6 @@ export default function RecordWriteScreen() {
         <ActivityIndicator size="large" color={colors.white} />
       </View>
     );
-  }
-
-  if (isErrorBookPageInfo || !bookPageInfo) {
-    Toast.show({
-      type: "error",
-      text1: bookPageInfoError?.message,
-    });
-    router.back();
-
-    return;
   }
 
   return (

--- a/src/apis/api-client.ts
+++ b/src/apis/api-client.ts
@@ -60,7 +60,7 @@ if (!baseURL) {
 
 const axiosInstance = create({
   baseURL,
-  timeout: 10000,
+  timeout: 15000,
 });
 
 axiosInstance.interceptors.request.use(async (config) => {

--- a/src/apis/room-post/index.ts
+++ b/src/apis/room-post/index.ts
@@ -52,3 +52,5 @@ export type {
   RoomPostSortType,
   RoomPostVote,
 } from "./room-post.types";
+
+export { ROOM_POST_QUERY_KEY } from "./room-post.query-key";

--- a/src/apis/room-post/index.ts
+++ b/src/apis/room-post/index.ts
@@ -17,6 +17,7 @@ export {
   useCreateRoomRecordMutation,
   useCreateRoomVoteMutation,
   useDeleteRoomPostMutation,
+  useDoRoomVoteMutation,
   useEditRoomRecordMutation,
   useEditRoomVoteMutation,
   useGetBookInfoForPinQuery,

--- a/src/apis/room-post/room-post.queries.ts
+++ b/src/apis/room-post/room-post.queries.ts
@@ -457,13 +457,29 @@ export const useDeleteRoomPostMutation = () => {
 };
 
 export const useDoRoomVoteMutation = () => {
+  const queryClient = useQueryClient();
+
   const { mutate: doVote, isPending: isPendingDoVote } = useMutation<
     DoRoomVoteResponse,
     ApiErrorResponse,
     DoRoomVoteRequest
   >({
     mutationFn: doRoomVoteApi,
-    onSuccess: () => {},
-    onError: () => {},
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({
+        queryKey: ROOM_POST_QUERY_KEY.ALL_POST(data.roomId),
+      });
+    },
+    onError: (error) => {
+      Toast.show({
+        type: "error",
+        text1: `${error.message}`,
+      });
+    },
   });
+
+  return {
+    doVote,
+    isPendingDoVote,
+  };
 };

--- a/src/apis/room-post/room-post.queries.ts
+++ b/src/apis/room-post/room-post.queries.ts
@@ -68,32 +68,6 @@ type RoomPostCursor = string | null;
 const hasRoomId = (roomId?: number | string): roomId is number | string =>
   roomId != null && roomId !== "";
 
-export const useChangeRoomPostLikeStatusMutation = () => {
-  const {
-    mutate: changeRoomPostLikeStatus,
-    isPending: isPendingChangeRoomPostLikeStatus,
-  } = useMutation<
-    ChangeRoomPostLikeStatusResponse,
-    Error,
-    ChangeRoomPostLikeStatusRequest
-  >({
-    mutationFn: changeRoomPostLikeStatusApi,
-    // TODO: roomId 정보를 얻을 수가 없어서 추후 사용하는 곳에서 onSuccess를 정의하는 것으로 해결한다. room-post의 캐시 초기화
-    onSuccess: () => {},
-    onError: (error) => {
-      Toast.show({
-        type: "error",
-        text1: `${error.message}`,
-      });
-    },
-  });
-
-  return {
-    changeRoomPostLikeStatus,
-    isPendingChangeRoomPostLikeStatus,
-  };
-};
-
 export const useGetRoomBookPageQuery = (roomId?: number | string) => {
   const {
     data: bookPageInfo,
@@ -481,5 +455,36 @@ export const useDoRoomVoteMutation = () => {
   return {
     doVote,
     isPendingDoVote,
+  };
+};
+
+export const useChangeRoomPostLikeStatusMutation = (roomId: number) => {
+  const queryClient = useQueryClient();
+
+  const {
+    mutate: changeRoomPostLikeStatus,
+    isPending: isPendingChangeRoomPostLikeStatus,
+  } = useMutation<
+    ChangeRoomPostLikeStatusResponse,
+    Error,
+    ChangeRoomPostLikeStatusRequest
+  >({
+    mutationFn: changeRoomPostLikeStatusApi,
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ROOM_POST_QUERY_KEY.ALL_POST(roomId),
+      });
+    },
+    onError: (error) => {
+      Toast.show({
+        type: "error",
+        text1: `${error.message}`,
+      });
+    },
+  });
+
+  return {
+    changeRoomPostLikeStatus,
+    isPendingChangeRoomPostLikeStatus,
   };
 };


### PR DESCRIPTION
## 📌 Related Issues

- close #155 
- close #156 

## 📄 Tasks

### 모임방 투표

- 투표 참여 및 취소 API 연동
- 투표 항목의 현재 선택 상태에 따라 참여·취소 요청 처리
- 게시글 ID와 투표 항목 ID를 API 요청에 전달
- 요청 처리 중 중복 투표 방지
- 투표 성공 후 모임방 게시글 목록 캐시 무효화
- 변경된 투표 선택 상태와 개수가 목록에 반영되도록 처리
- 투표 실패 시 에러 Toast 표시

### 게시글 좋아요

- 기록 및 투표 게시글 좋아요 API 연동
- 현재 좋아요 상태에 따라 좋아요·취소 요청 처리
- 게시글 유형을 API 요청에 전달
- 요청 처리 중 중복 클릭 방지
- 좋아요 성공 후 해당 모임방 게시글 목록 캐시 무효화
- 좋아요 아이콘과 개수가 갱신되도록 처리
- 요청 실패 시 에러 Toast 표시

### 모임방 댓글

- 더미 댓글 데이터를 실제 댓글 조회 API로 교체
- 기록 및 투표 게시글 유형을 댓글 조회·작성 요청에 전달
- 커서 기반 댓글 무한 스크롤 구현
- 댓글 작성 API 연동
- 답글 대상 선택 및 답글 작성 API 연동
- 댓글 작성 성공 시 입력값과 답글 대상 초기화
- 댓글 작성 성공 후 게시글 목록 캐시를 갱신하여 댓글 수 반영
- 댓글 목록 로딩·에러·빈 상태 UI 처리
- 댓글 조회 및 작성 중 입력 중복 요청 방지
- 댓글 바텀시트 진입 시 최신 댓글 목록 재조회
- 피드 상세 댓글 조회 실패 메시지에 서버 에러 내용 표시

### 기록장 새로고침

- Pull-to-refresh 시 기록 목록과 책 페이지 정보를 함께 재조회
- 두 요청의 갱신 상태를 새로고침 인디케이터에 반영

### 렌더링 타이밍 오류 수정

- 컴포넌트 렌더링 중 실행되던 `Toast.show()`와 `router.back()` 제거
- Toast 표시와 화면 이동을 `useEffect`에서 처리하도록 변경
- 잘못된 접근 및 페이지 정보 조회 실패 처리 개선
- 다음 화면에서 발생하던 렌더링 상태 변경 경고 수정
  - 기록장
  - 기록 작성
  - 투표 작성
  - 오늘의 한마디
- `Cannot update a component while rendering a different component` 경고 원인 제거

### 기타 변경

- API 요청 타임아웃을 10초에서 15초로 조정
- 마이페이지 앱 버전 표기를 `1.3.0`으로 변경
- `ROOM_POST_QUERY_KEY` 외부 export 추가


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 게시글의 좋아요와 투표가 실제로 반영되며, 처리 중 중복 요청을 방지합니다.
  * 게시글별 댓글을 불러오고 작성할 수 있으며, 새 댓글 작성 후 목록이 자동 갱신됩니다.
  * 댓글 로딩, 오류, 빈 상태를 구분해 안내합니다.

* **버그 수정**
  * 잘못된 접근이나 도서 정보 조회 실패 시 오류 안내 후 이전 화면으로 이동합니다.
  * 댓글 불러오기 실패 시 구체적인 오류 메시지를 표시합니다.

* **개선**
  * 설정 화면의 앱 버전 표기가 1.3.0으로 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->