### PR TITLE
[Feature/#123] 푸시알림 기능 연동 및 모임방 관련 수정사항 반영

### DIFF
--- a/screens/create-vote/create-vote-screen.tsx
+++ b/screens/create-vote/create-vote-screen.tsx
@@ -73,9 +73,10 @@ export default function CreateVoteScreen() {
     if (isPendingCreateRoomVote || isPendingEditRoomVote) return;
 
     if (prevRecord === null) {
+      if (!bookPageInfo) return;
       createRoomVote({
         roomId,
-        page: recordPage,
+        page: isOverview ? bookPageInfo.totalBookPage : recordPage,
         isOverview,
         content,
         voteItemList: cleanedVoteItemList,

--- a/screens/group-detail/components/votes-carousel/index.tsx
+++ b/screens/group-detail/components/votes-carousel/index.tsx
@@ -9,6 +9,7 @@ import Carousel, {
 } from "react-native-reanimated-carousel";
 
 import { AppText } from "@shared/ui";
+import { useRoomDetailVoteStore } from "@stores/record-book";
 import { colors } from "@theme/token";
 
 import { CurrentVoteType } from "../../types";
@@ -42,6 +43,7 @@ const getVotesCarouselHeight = (currentVotes: CurrentVoteType[]) => {
 };
 
 const VotesCarouselItem = ({ roomId, vote }: VotesCarouselItemProps) => {
+  const { setRoomDetailVote } = useRoomDetailVoteStore();
   const pressStartRef = useRef<{ x: number; y: number } | null>(null);
 
   const handlePressIn = useCallback((event: GestureResponderEvent) => {
@@ -67,13 +69,13 @@ const VotesCarouselItem = ({ roomId, vote }: VotesCarouselItemProps) => {
         return;
       }
 
-      // TODO: 추후 특정 페이지로 이동하도록 수정 필요.
+      setRoomDetailVote(vote);
       router.push({
         pathname: "/record-book/[roomId]",
         params: { roomId: String(roomId) },
       });
     },
-    [roomId],
+    [roomId, setRoomDetailVote, vote],
   );
 
   return (

--- a/screens/group-detail/group-detail-screen.tsx
+++ b/screens/group-detail/group-detail-screen.tsx
@@ -1,5 +1,5 @@
 import { router, useLocalSearchParams } from "expo-router";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import {
   ActivityIndicator,
   RefreshControl,
@@ -12,6 +12,7 @@ import Toast from "react-native-toast-message";
 
 import { useGetRoomDetailQuery, useLeaveRoomMutation } from "@apis/room";
 import { AppText, GroupInfo } from "@shared/ui";
+import { getCurrentDate, parseStringToDate } from "@shared/utils";
 import { colors } from "@theme/token";
 
 import {
@@ -121,6 +122,27 @@ export default function GroupDetailScreen() {
 
   const disabledHeaderOption =
     !roomDetailData || isPendingRoomDetail || isErrorRoomDetail;
+
+  useEffect(() => {
+    const progressEndDate = roomDetailData?.progressEndDate;
+
+    if (!progressEndDate) return;
+
+    const endDate = parseStringToDate(progressEndDate);
+
+    if (!endDate) return;
+
+    const { currentYear, currentMonth, currentDay } = getCurrentDate();
+
+    const today = new Date(currentYear, currentMonth - 1, currentDay);
+
+    if (endDate < today) {
+      Toast.show({
+        type: "default",
+        text1: "완료된 모임방에서는 기존 기록에 대한 조회만 가능해요.",
+      });
+    }
+  }, [roomDetailData?.progressEndDate]);
 
   return (
     <View style={styles.page}>

--- a/screens/record-book/components/record-book-filter/index.tsx
+++ b/screens/record-book/components/record-book-filter/index.tsx
@@ -14,6 +14,10 @@ interface RecordBookFilterProps {
   pageSettingMode: boolean;
   isDropdownVisible: boolean;
   sortType: RoomPostSortTypeWithLabel;
+  selectedPages: {
+    start: number | null;
+    end: number | null;
+  };
   handlePressPageChip: () => void;
   handleResetPage: () => void;
   handleApplyPage: (start: number | null, end: number | null) => void;
@@ -24,6 +28,7 @@ interface RecordBookFilterProps {
 
 export default function RecordBookFilter({
   selectedChip,
+  selectedPages,
   pageSettingMode,
   isDropdownVisible,
   sortType,
@@ -34,8 +39,12 @@ export default function RecordBookFilter({
   handlePressDropdown,
   handleSelectType,
 }: RecordBookFilterProps) {
-  const [startPage, setStartPage] = useState("");
-  const [endPage, setEndPage] = useState("");
+  const [startPage, setStartPage] = useState(
+    selectedPages.start ? String(selectedPages.start) : "",
+  );
+  const [endPage, setEndPage] = useState(
+    selectedPages.end ? String(selectedPages.end) : "",
+  );
 
   const handleReset = () => {
     setStartPage("");

--- a/screens/record-book/components/record-book-floating/index.tsx
+++ b/screens/record-book/components/record-book-floating/index.tsx
@@ -29,6 +29,7 @@ export default function RecordBookFloating({
       pathname: "/record-write/[roomId]",
       params: { roomId },
     });
+    setIsOptionOpen(false);
   };
 
   const handleToCreateVote = () => {
@@ -36,6 +37,7 @@ export default function RecordBookFloating({
       pathname: "/create-vote/[roomId]",
       params: { roomId },
     });
+    setIsOptionOpen(false);
   };
 
   return (

--- a/screens/record-book/record-book-screen.tsx
+++ b/screens/record-book/record-book-screen.tsx
@@ -1,4 +1,4 @@
-import { router, useLocalSearchParams } from "expo-router";
+import { router, useLocalSearchParams, useNavigation } from "expo-router";
 import { useEffect, useState } from "react";
 import {
   ActivityIndicator,
@@ -17,6 +17,10 @@ import {
 } from "@apis/room-post";
 import { IcAlertGrey } from "@images/icons";
 import { AppText } from "@shared/ui";
+import {
+  useRecordBookAlarmStore,
+  useRoomDetailVoteStore,
+} from "@stores/record-book";
 import { colors } from "@theme/token";
 
 import {
@@ -32,25 +36,52 @@ import { RoomPostSortTypeWithLabel } from "./types";
 
 export default function RecordBookScreen() {
   const { bottom } = useSafeAreaInsets();
+  const navigation = useNavigation();
   const { roomId } = useLocalSearchParams<{ roomId: string }>();
+  const { recordBookAlarmInfo, clearRecordBookAlarmInfo } =
+    useRecordBookAlarmStore();
+  const { roomDetailVote, clearRoomDetailVote } = useRoomDetailVoteStore();
   const [isMyRecord, setIsMyRecord] = useState(false);
   const [selectedChip, setSelectedChip] = useState<"page" | "overview" | null>(
-    null,
+    recordBookAlarmInfo
+      ? "page"
+      : roomDetailVote
+        ? roomDetailVote.isOverview
+          ? "overview"
+          : "page"
+        : null,
   );
   const [pageSettingMode, setPageSettingMode] = useState(false);
   const [selectedPages, setSelectedPages] = useState<{
     start: number | null;
     end: number | null;
-  }>({ start: null, end: null });
+  }>({
+    start: recordBookAlarmInfo
+      ? recordBookAlarmInfo.page
+      : roomDetailVote && !roomDetailVote.isOverview
+        ? roomDetailVote.page
+        : null,
+    end: recordBookAlarmInfo
+      ? recordBookAlarmInfo.page
+      : roomDetailVote && !roomDetailVote.isOverview
+        ? roomDetailVote.page
+        : null,
+  });
 
   const [sortType, setSortType] = useState<RoomPostSortTypeWithLabel>(
     GROUP_RECORD_SORT[0],
   );
   const [isDropdownVisible, setIsDropdownVisible] = useState(false);
-  const [isCommentOpen, setIsCommentOpen] = useState(false);
-  const [postIdForComment, setPostIdForComment] = useState<number | null>(null);
+  const [isCommentOpen, setIsCommentOpen] = useState(
+    recordBookAlarmInfo ? recordBookAlarmInfo.openComments : false,
+  );
+  const [postIdForComment, setPostIdForComment] = useState<number | null>(
+    recordBookAlarmInfo ? recordBookAlarmInfo.postId : null,
+  );
   const [postTypeForComment, setPostTypeForComment] =
-    useState<RoomPostType | null>(null);
+    useState<RoomPostType | null>(
+      recordBookAlarmInfo ? recordBookAlarmInfo.postType : null,
+    );
 
   const {
     bookPageInfo,
@@ -200,6 +231,13 @@ export default function RecordBookScreen() {
     }
   }, [isErrorBookPageInfo, bookPageInfoError?.message]);
 
+  useEffect(() => {
+    return navigation.addListener("beforeRemove", () => {
+      clearRecordBookAlarmInfo();
+      clearRoomDetailVote();
+    });
+  }, [clearRecordBookAlarmInfo, clearRoomDetailVote, navigation]);
+
   if (!roomId || isErrorBookPageInfo) return null;
 
   const RecordListHeader = () => {
@@ -270,6 +308,7 @@ export default function RecordBookScreen() {
       {!isMyRecord && (
         <RecordBookFilter
           selectedChip={selectedChip}
+          selectedPages={selectedPages}
           pageSettingMode={pageSettingMode}
           isDropdownVisible={isDropdownVisible}
           sortType={sortType}

--- a/screens/record-write/record-write-screen.tsx
+++ b/screens/record-write/record-write-screen.tsx
@@ -71,9 +71,10 @@ export default function RecordWriteScreen() {
     if (isPendingCreateRoomRecord || isPendingEditRoomRecord) return;
 
     if (prevRecord === null) {
+      if (!bookPageInfo) return;
       createRoomRecord({
         roomId,
-        page: recordPage,
+        page: isOverview ? bookPageInfo.totalBookPage : recordPage,
         isOverview,
         content,
       });

--- a/src/apis/notification/index.ts
+++ b/src/apis/notification/index.ts
@@ -29,6 +29,7 @@ export type {
   GetUncheckedNotificationExistsResponse,
   NotificationItemType,
   NotificationRoute,
+  NotificationRouteParamMap,
   NotificationType,
   RegisterNotificationTokenRequest,
 } from "./notification.types";

--- a/src/apis/notification/notification.queries.ts
+++ b/src/apis/notification/notification.queries.ts
@@ -11,10 +11,13 @@ import { useEffect } from "react";
 import Toast from "react-native-toast-message";
 
 import { getFormattedCurrentDateTime } from "@shared/utils";
+import { useRecordBookAlarmStore } from "@stores/record-book";
 
 import { ApiErrorResponse } from "../api-client";
 import { COMMENT_QUERY_KEY } from "../comment";
 import { FEED_QUERY_KEY } from "../feed";
+import { ROOM_QUERY_KEY } from "../room";
+import { ROOM_POST_QUERY_KEY } from "../room-post";
 import {
   changePushNotificationStateApi,
   checkNotificationApi,
@@ -160,6 +163,8 @@ const shouldRetryNotificationCheck = (failureCount: number, error: Error) =>
 
 export const useCheckNotification = () => {
   const queryClient = useQueryClient();
+  const { setRecordBookAlarmInfo } = useRecordBookAlarmStore();
+
   const {
     mutate: checkNotification,
     isPending: isPendingCheckNotification,
@@ -173,37 +178,63 @@ export const useCheckNotification = () => {
       queryClient.invalidateQueries({
         queryKey: NOTIFICATION_QUERY_KEY.ALL,
       });
-      if (data.route === NOTIFICATION_ROUTE.FEED_USER) {
-        router.push({
-          pathname: "/user-profile/[userId]",
-          params: { userId: data.params.userId },
-        });
-      } else if (data.route === NOTIFICATION_ROUTE.FEED_DETAIL) {
-        router.push({
-          pathname: "/feed-detail/[feedId]",
-          params: { feedId: data.params.feedId },
-        });
-        queryClient.invalidateQueries({
-          queryKey: FEED_QUERY_KEY.DETAIL(data.params.feedId),
-        });
-        queryClient.invalidateQueries({
-          queryKey: COMMENT_QUERY_KEY.LIST(data.params.feedId, "FEED"),
-        });
-      } else if (
-        data.route === NOTIFICATION_ROUTE.ROOM_MAIN ||
-        data.route === NOTIFICATION_ROUTE.ROOM_DETAIL
-      ) {
-        // TODO: 추후 모임방 관련 시 쿼리 캐시 초기화 추가
-        router.push({
-          pathname: "/group-detail/[roomId]",
-          params: { roomId: data.params.roomId },
-        });
-      } else if (data.route === NOTIFICATION_ROUTE.ROOM_POST_DETAIL) {
-        // TODO: 이 경우에는 받은 params를 이용하여 해당 기록 위치를 보여주고, openComments 여부에 따라 댓글 바텀시트도 조작한다. 쿼리 캐시도 초기화
-        router.push({
-          pathname: "/group-detail/[roomId]",
-          params: { roomId: data.params.roomId },
-        });
+      switch (data.route) {
+        case NOTIFICATION_ROUTE.FEED_USER:
+          router.push({
+            pathname: "/user-profile/[userId]",
+            params: { userId: data.params.userId },
+          });
+          break;
+        case NOTIFICATION_ROUTE.FEED_DETAIL:
+          router.push({
+            pathname: "/feed-detail/[feedId]",
+            params: { feedId: data.params.feedId },
+          });
+          queryClient.invalidateQueries({
+            queryKey: FEED_QUERY_KEY.DETAIL(data.params.feedId),
+          });
+          queryClient.invalidateQueries({
+            queryKey: COMMENT_QUERY_KEY.LIST(data.params.feedId, "FEED"),
+          });
+          break;
+        case NOTIFICATION_ROUTE.ROOM_MAIN:
+          router.push({
+            pathname: "/group-detail/[roomId]",
+            params: { roomId: data.params.roomId },
+          });
+          queryClient.invalidateQueries({
+            queryKey: ROOM_QUERY_KEY.ALL,
+          });
+          break;
+        case NOTIFICATION_ROUTE.ROOM_DETAIL:
+          router.push({
+            pathname: "/join-group/[roomId]",
+            params: { roomId: data.params.roomId },
+          });
+          queryClient.invalidateQueries({
+            queryKey: ROOM_QUERY_KEY.ALL,
+          });
+          break;
+        case NOTIFICATION_ROUTE.ROOM_POST_DETAIL:
+          setRecordBookAlarmInfo(data.params);
+          router.push({
+            pathname: "/record-book/[roomId]",
+            params: { roomId: data.params.roomId },
+          });
+          queryClient.invalidateQueries({
+            queryKey: ROOM_POST_QUERY_KEY.ALL_POST(data.params.roomId),
+          });
+          if (data.params.openComments) {
+            queryClient.invalidateQueries({
+              queryKey: COMMENT_QUERY_KEY.LIST(
+                data.params.postId,
+                data.params.postType,
+              ),
+            });
+          }
+          break;
+        default:
+          router.push("/alarm");
       }
     },
   });

--- a/src/apis/room/room.queries.ts
+++ b/src/apis/room/room.queries.ts
@@ -245,7 +245,7 @@ export const useCreateRoomMutation = () => {
         text1: "모임방 생성이 완료되었습니다.",
       });
       router.replace({
-        pathname: "/group-detail/[roomId]",
+        pathname: "/join-group/[roomId]",
         params: { roomId: data.roomId },
       });
     },

--- a/src/stores/record-book/index.ts
+++ b/src/stores/record-book/index.ts
@@ -1,5 +1,7 @@
 import { create } from "zustand";
 
+import { type NotificationRouteParamMap } from "@apis/notification";
+import { type RoomDetailCurrentVotes } from "@apis/room";
 import {
   type GetBookInfoForPinResponse,
   type RoomPostVote,
@@ -40,4 +42,30 @@ export const useRecordBookPinStore = create<RecordBookPinStore>((set) => ({
   pinInfo: null,
   setPinInfo: (pinInfo) => set({ pinInfo }),
   clearPinInfo: () => set({ pinInfo: null }),
+}));
+
+interface RecordBookAlarmStore {
+  recordBookAlarmInfo: NotificationRouteParamMap["ROOM_POST_DETAIL"] | null;
+  setRecordBookAlarmInfo: (
+    recordBookAlarmInfo: NotificationRouteParamMap["ROOM_POST_DETAIL"],
+  ) => void;
+  clearRecordBookAlarmInfo: () => void;
+}
+
+export const useRecordBookAlarmStore = create<RecordBookAlarmStore>((set) => ({
+  recordBookAlarmInfo: null,
+  setRecordBookAlarmInfo: (recordBookAlarmInfo) => set({ recordBookAlarmInfo }),
+  clearRecordBookAlarmInfo: () => set({ recordBookAlarmInfo: null }),
+}));
+
+interface RoomDetailVoteStore {
+  roomDetailVote: RoomDetailCurrentVotes | null;
+  setRoomDetailVote: (roomDetailVote: RoomDetailCurrentVotes) => void;
+  clearRoomDetailVote: () => void;
+}
+
+export const useRoomDetailVoteStore = create<RoomDetailVoteStore>((set) => ({
+  roomDetailVote: null,
+  setRoomDetailVote: (roomDetailVote) => set({ roomDetailVote }),
+  clearRoomDetailVote: () => set({ roomDetailVote: null }),
 }));


### PR DESCRIPTION
## 📌 Related Issues

- close #123 
- close #149 

## 📄 Tasks

푸시 알림 유형에 따라 관련 화면으로 이동하도록 알림 라우팅을 구현했습니다.

모임방 게시글 알림으로 진입한 경우 해당 기록의 페이지 필터를 적용하고, 댓글 알림이면 댓글 바텀시트까지 자동으로 열리도록 처리했습니다. 진행 중인 투표에서 관련 기록으로 이동하는 기능과 완료된 모임방 안내도 함께 반영했습니다.

### 푸시 알림 화면 이동

알림 확인 API 응답의 `route` 값에 따라 이동할 화면을 분기했습니다.

- `FEED_USER`
  - 사용자 프로필 화면으로 이동
- `FEED_DETAIL`
  - 피드 상세 화면으로 이동
  - 피드 상세 및 댓글 목록 캐시 무효화
- `ROOM_MAIN`
  - 참여 중인 모임방 메인 화면으로 이동
  - 모임방 관련 캐시 무효화
- `ROOM_DETAIL`
  - 모임방 참여 상세 화면으로 이동
  - 모임방 관련 캐시 무효화
- `ROOM_POST_DETAIL`
  - 모임방 기록장으로 이동
  - 해당 모임의 기록 목록 캐시 무효화
  - 댓글 알림인 경우 해당 게시글 댓글 목록 캐시 무효화
- 알 수 없는 라우트
  - 알림 목록 화면으로 이동

알림 확인 후 알림 목록 캐시도 함께 갱신하도록 처리했습니다.

### 모임방 게시글 알림 처리

- 게시글 알림에 포함된 정보를 Zustand 스토어에 저장
  - 모임방 ID
  - 게시글 ID
  - 게시글 유형
  - 페이지
  - 댓글 바텀시트 자동 실행 여부
- 알림으로 기록장에 진입하면 해당 페이지 필터를 자동 적용
- 댓글 알림이면 대상 게시글의 댓글 바텀시트를 자동으로 표시
- 기록장 이탈 시 알림 진입 정보를 초기화
- `NotificationRouteParamMap` 타입을 외부에서 사용할 수 있도록 export

### 진행 중인 투표에서 기록장 이동

- 모임방 메인의 진행 중인 투표를 누르면 기록장으로 이동
- 선택한 투표의 페이지 및 총평 여부를 스토어에 저장
- 일반 기록이면 해당 페이지 필터 자동 적용
- 총평 기록이면 총평 필터 자동 적용
- 기록장 이탈 시 투표 이동 정보를 초기화

### 기록장 필터 상태

- 외부에서 전달된 페이지 필터 값을 필터 입력창 초기값에 반영
- 알림 또는 진행 중인 투표로 진입했을 때 선택된 필터와 실제 입력값을 동기화
- 기록 및 투표 작성 화면으로 이동한 뒤 플로팅 메뉴가 닫히도록 처리

### 완료된 모임방 안내

- 모임방 종료일을 한국 기준 오늘 날짜와 비교
- 종료일이 오늘보다 이전이면 안내 Toast 표시
- 완료된 모임방에서는 기존 기록 조회만 가능하다는 메시지 제공

### 생성 흐름 보정

- 모임방 생성 완료 후 모임방 참여 상세 화면으로 이동하도록 수정
- 총평 기록 및 투표 생성 시 전체 페이지 수를 기록 페이지 값으로 전달
- 기록 및 투표 생성 전 책 페이지 정보 존재 여부 확인



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 알림에서 관련 화면과 댓글로 정확히 이동할 수 있습니다.
  - 종료된 모임방에서는 기존 기록만 조회할 수 있습니다.
  - 투표 선택 후 기록 화면에서 선택 정보가 유지됩니다.
  - 기록 필터가 기존 페이지 범위를 반영합니다.

- **버그 수정**
  - 개요 및 일반 기록 작성 시 페이지 정보가 올바르게 저장됩니다.
  - 모임 생성 후 참여 화면으로 정상 이동합니다.
  - 기록 작성 또는 투표 생성 후 옵션 메뉴가 자동으로 닫힙니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->